### PR TITLE
feat(cms): admin UX overhaul — login redesign, dashboard stats, and CMS overrides for code-defined articles

### DIFF
--- a/src/app/api/admin/posts/route.ts
+++ b/src/app/api/admin/posts/route.ts
@@ -37,8 +37,11 @@ export async function POST(request: NextRequest) {
     const { input, error } = validatePostInput(raw);
     if (!input) return NextResponse.json({ error }, { status: 400 });
 
+    // Explicit opt-in lets the CMS override a code-defined article by reusing its slug.
+    const allowStaticSlug = (raw as Record<string, unknown>).overrideStatic === true;
+
     try {
-        const post = await createDbPost(input);
+        const post = await createDbPost(input, { allowStaticSlug });
         revalidateBlog(post.slug);
         return NextResponse.json({ post }, { status: 201 });
     } catch (err) {

--- a/src/app/super-admin/login/page.tsx
+++ b/src/app/super-admin/login/page.tsx
@@ -1,20 +1,59 @@
 import { Suspense } from 'react';
+import Link from 'next/link';
 import LoginForm from '@/components/admin/LoginForm';
 
 export default function AdminLoginPage() {
     return (
-        <div className="min-h-screen flex items-center justify-center px-6">
-            <div className="w-full max-w-md">
-                <div className="text-center mb-10">
-                    <div className="inline-flex items-baseline gap-2 select-none mb-3">
+        <div className="relative min-h-screen flex items-center justify-center px-6 py-16 overflow-hidden">
+            {/* Decorative backdrop */}
+            <div aria-hidden className="absolute inset-0 pointer-events-none">
+                <div className="absolute -top-40 -right-40 w-[480px] h-[480px] rounded-full bg-accent/10 blur-3xl" />
+                <div className="absolute -bottom-40 -left-40 w-[480px] h-[480px] rounded-full bg-accent/5 blur-3xl" />
+                <div
+                    className="absolute inset-0 opacity-[0.35]"
+                    style={{
+                        backgroundImage: 'linear-gradient(rgba(var(--border)) 1px, transparent 1px), linear-gradient(90deg, rgba(var(--border)) 1px, transparent 1px)',
+                        backgroundSize: '48px 48px',
+                        maskImage: 'radial-gradient(ellipse 70% 60% at 50% 45%, black 30%, transparent 75%)',
+                        WebkitMaskImage: 'radial-gradient(ellipse 70% 60% at 50% 45%, black 30%, transparent 75%)',
+                    }}
+                />
+            </div>
+
+            <Link
+                href="/"
+                className="absolute top-6 left-6 z-10 flex items-center gap-2 text-sm font-semibold text-foreground-secondary hover:text-foreground transition-colors"
+            >
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                    <path d="m12 19-7-7 7-7" /><path d="M19 12H5" />
+                </svg>
+                Back to website
+            </Link>
+
+            <div className="relative w-full max-w-md">
+                <div className="text-center mb-8">
+                    <div className="inline-flex items-center justify-center w-14 h-14 rounded-2xl bg-accent-gradient shadow-button mb-5">
+                        <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="white" strokeWidth="2.25" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                            <rect width="18" height="11" x="3" y="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                        </svg>
+                    </div>
+                    <div className="flex items-baseline justify-center gap-2 select-none mb-2">
                         <span className="font-extrabold text-2xl tracking-tighter text-foreground">BRYNEX</span>
                         <span className="text-xs font-black tracking-[0.3em] text-accent uppercase">CMS</span>
                     </div>
-                    <p className="text-foreground-secondary text-sm">Sign in to manage articles</p>
+                    <p className="text-foreground-secondary text-sm">Sign in to manage articles and publishing</p>
                 </div>
+
                 <Suspense>
                     <LoginForm />
                 </Suspense>
+
+                <p className="mt-8 text-center text-xs text-foreground-muted">
+                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="inline -mt-0.5 mr-1.5">
+                        <path d="M20 13c0 5-3.5 7.5-7.66 8.95a1 1 0 0 1-.67-.01C7.5 20.5 4 18 4 13V6a1 1 0 0 1 1-1c2 0 4.5-1.2 6.24-2.72a1.17 1.17 0 0 1 1.52 0C14.51 3.81 17 5 19 5a1 1 0 0 1 1 1z" />
+                    </svg>
+                    Restricted area — authorized personnel only
+                </p>
             </div>
         </div>
     );

--- a/src/app/super-admin/page.tsx
+++ b/src/app/super-admin/page.tsx
@@ -20,8 +20,32 @@ export default async function AdminDashboard() {
         }
     }
 
+    const published = posts.filter((p) => p.status === 'published').length;
+    const drafts = posts.length - published;
+    const dbSlugs = new Set(posts.map((p) => p.slug));
+    const staticSlugs = staticPosts.map((p) => p.slug);
+    const overriddenCount = staticSlugs.filter((s) => dbSlugs.has(s)).length;
+
+    const stats = [
+        { label: 'CMS Articles', value: posts.length },
+        { label: 'Published', value: published, accent: 'text-green-500' },
+        { label: 'Drafts', value: drafts, accent: drafts > 0 ? 'text-amber-500' : undefined },
+        { label: 'Code-Defined', value: staticPosts.length, note: overriddenCount > 0 ? `${overriddenCount} overridden` : undefined },
+    ];
+
     return (
-        <AdminShell title="Articles">
+        <AdminShell
+            title="Articles"
+            subtitle="Everything published on /blog — CMS-managed and code-defined."
+            actions={
+                <Link
+                    href="/super-admin/posts/new"
+                    className="inline-block px-5 py-2.5 rounded-xl bg-accent-gradient text-white text-sm font-bold shadow-button hover:brightness-110 transition-all"
+                >
+                    + New Article
+                </Link>
+            }
+        >
             {!dbConfigured && (
                 <div className="mb-8 rounded-xl border border-amber-500/30 bg-amber-500/10 px-5 py-4 text-sm text-foreground-secondary">
                     <span className="font-bold text-amber-500">MongoDB is not configured.</span>{' '}
@@ -34,39 +58,60 @@ export default async function AdminDashboard() {
                 </div>
             )}
 
-            <div className="flex items-center justify-between mb-6">
-                <p className="text-foreground-secondary text-sm">
-                    <span className="font-bold text-foreground">{posts.length}</span> CMS article{posts.length === 1 ? '' : 's'}
-                    <span className="mx-2 text-border">·</span>
-                    <span className="font-bold text-foreground">{staticPosts.length}</span> code-defined
-                </p>
-                <Link
-                    href="/super-admin/posts/new"
-                    className="px-5 py-2.5 rounded-xl bg-accent-gradient text-white text-sm font-bold shadow-button hover:brightness-110 transition-all"
-                >
-                    + New Article
-                </Link>
+            {/* Stats */}
+            <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-8">
+                {stats.map((stat) => (
+                    <div key={stat.label} className="rounded-xl border border-border bg-background-card px-5 py-4">
+                        <p className={`text-2xl font-black tracking-tight ${stat.accent ?? 'text-foreground'}`}>{stat.value}</p>
+                        <p className="text-xs font-bold uppercase tracking-widest text-foreground-secondary mt-1">
+                            {stat.label}
+                            {stat.note && <span className="ml-2 normal-case tracking-normal font-semibold text-accent">· {stat.note}</span>}
+                        </p>
+                    </div>
+                ))}
             </div>
 
-            <AdminPostList posts={posts} />
+            <AdminPostList posts={posts} staticSlugs={staticSlugs} />
 
-            {/* Code-defined posts (read-only) */}
+            {/* Code-defined posts — editable via CMS override */}
             <div className="mt-12">
-                <h2 className="text-sm font-black uppercase tracking-widest text-foreground-secondary mb-4">Code-Defined Articles (read-only)</h2>
+                <h2 className="text-sm font-black uppercase tracking-widest text-foreground-secondary mb-2">Code-Defined Articles</h2>
+                <p className="text-xs text-foreground-muted mb-4">
+                    These live in the codebase (src/data/blog.tsx). Hitting <span className="font-bold text-foreground">Edit</span> creates a CMS copy that replaces the original on the live site — delete the copy to restore it.
+                </p>
                 <div className="space-y-2">
-                    {staticPosts.map((post) => (
-                        <div key={post.slug} className="flex items-center justify-between gap-4 rounded-xl border border-border/60 bg-background-secondary/30 px-5 py-3.5">
-                            <div className="min-w-0">
-                                <p className="font-bold text-foreground-secondary truncate">{post.title}</p>
-                                <p className="text-xs text-foreground-muted">/blog/{post.slug} · {post.category} · {post.date}</p>
+                    {staticPosts.map((post) => {
+                        const overridden = dbSlugs.has(post.slug);
+                        return (
+                            <div key={post.slug} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 rounded-xl border border-border/60 bg-background-secondary/30 px-5 py-3.5">
+                                <div className="min-w-0">
+                                    <div className="flex items-center gap-2.5">
+                                        <p className={`font-bold truncate ${overridden ? 'text-foreground-muted line-through decoration-border' : 'text-foreground-secondary'}`}>{post.title}</p>
+                                        {overridden && (
+                                            <span className="shrink-0 px-2 py-0.5 rounded-full text-[10px] font-black uppercase tracking-wider bg-accent/10 text-accent border border-accent/30">
+                                                Overridden by CMS
+                                            </span>
+                                        )}
+                                    </div>
+                                    <p className="text-xs text-foreground-muted mt-0.5">/blog/{post.slug} · {post.category} · {post.date}</p>
+                                </div>
+                                <div className="flex items-center gap-2 shrink-0">
+                                    <Link href={`/blog/${post.slug}`} target="_blank" className="px-3.5 py-2 rounded-lg text-xs font-bold text-foreground-muted hover:text-accent transition-colors">
+                                        View ↗
+                                    </Link>
+                                    {!overridden && (
+                                        <Link
+                                            href={`/super-admin/posts/${post.slug}/edit`}
+                                            className="px-4 py-2 rounded-lg border border-border text-xs font-bold text-foreground hover:border-accent transition-colors"
+                                        >
+                                            Edit
+                                        </Link>
+                                    )}
+                                </div>
                             </div>
-                            <Link href={`/blog/${post.slug}`} target="_blank" className="shrink-0 text-xs font-bold text-foreground-muted hover:text-accent transition-colors">
-                                View ↗
-                            </Link>
-                        </div>
-                    ))}
+                        );
+                    })}
                 </div>
-                <p className="mt-3 text-xs text-foreground-muted">These live in the codebase (src/data/blog.tsx) and can only be changed by a developer.</p>
             </div>
         </AdminShell>
     );

--- a/src/app/super-admin/posts/[slug]/edit/page.tsx
+++ b/src/app/super-admin/posts/[slug]/edit/page.tsx
@@ -1,17 +1,32 @@
 import { notFound } from 'next/navigation';
 import AdminShell from '@/components/admin/AdminShell';
 import PostEditor from '@/components/admin/PostEditor';
-import { getDbPostBySlug } from '@/lib/blogStore';
+import { getDbPostBySlug, isStaticSlug } from '@/lib/blogStore';
+import { blogPosts as staticPosts } from '@/data/blog';
 
 export const dynamic = 'force-dynamic';
 
 export default async function EditPostPage({ params }: { params: { slug: string } }) {
     const post = await getDbPostBySlug(params.slug, { includeDrafts: true });
-    if (!post) notFound();
+
+    if (post) {
+        return (
+            <AdminShell
+                title="Edit Article"
+                subtitle={isStaticSlug(post.slug) ? 'CMS override of a code-defined article' : `/blog/${post.slug}`}
+            >
+                <PostEditor mode="edit" initialPost={post} />
+            </AdminShell>
+        );
+    }
+
+    // No CMS copy yet — editing a code-defined article creates an override.
+    const staticPost = staticPosts.find((p) => p.slug === params.slug);
+    if (!staticPost) notFound();
 
     return (
-        <AdminShell title="Edit Article">
-            <PostEditor mode="edit" initialPost={post} />
+        <AdminShell title="Edit Article" subtitle="Code-defined article — saving creates a CMS override">
+            <PostEditor mode="override" initialPost={staticPost} />
         </AdminShell>
     );
 }

--- a/src/app/super-admin/posts/new/page.tsx
+++ b/src/app/super-admin/posts/new/page.tsx
@@ -5,7 +5,7 @@ export const dynamic = 'force-dynamic';
 
 export default function NewPostPage() {
     return (
-        <AdminShell title="New Article">
+        <AdminShell title="New Article" subtitle="Draft it, preview it, publish it — live on /blog the moment you hit Publish.">
             <PostEditor mode="create" />
         </AdminShell>
     );

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -89,7 +89,6 @@ export default function Footer() {
                             {[
                                 { label: 'Privacy Policy', href: '/privacy' },
                                 { label: 'Terms of Service', href: '/terms' },
-                                { label: 'Admin', href: '/super-admin' },
                             ].map(link => (
                                 <li key={link.label}>
                                     <Link
@@ -130,7 +129,18 @@ export default function Footer() {
                             </span>
                         </div>
                     </div>
-                    <ThemeToggle />
+                    <div className="flex items-center gap-5">
+                        <Link
+                            href="/super-admin"
+                            className="flex items-center gap-1.5 text-foreground-muted text-xs hover:text-accent transition-colors duration-200"
+                        >
+                            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                                <rect width="18" height="11" x="3" y="11" rx="2" ry="2" /><path d="M7 11V7a5 5 0 0 1 10 0v4" />
+                            </svg>
+                            Admin
+                        </Link>
+                        <ThemeToggle />
+                    </div>
                 </div>
             </div>
         </footer>

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+
+const LINKS = [
+    { href: '/super-admin', label: 'Articles' },
+    { href: '/super-admin/posts/new', label: 'New Article' },
+];
+
+export default function AdminNav() {
+    const pathname = usePathname();
+
+    return (
+        <nav className="hidden sm:flex items-center gap-1 text-sm">
+            {LINKS.map(({ href, label }) => {
+                const active = pathname === href;
+                return (
+                    <Link
+                        key={href}
+                        href={href}
+                        aria-current={active ? 'page' : undefined}
+                        className={`px-3 py-1.5 rounded-lg font-semibold transition-colors ${
+                            active
+                                ? 'text-accent bg-accent/10'
+                                : 'text-foreground-secondary hover:text-foreground hover:bg-background-secondary'
+                        }`}
+                    >
+                        {label}
+                    </Link>
+                );
+            })}
+        </nav>
+    );
+}

--- a/src/components/admin/AdminPostList.tsx
+++ b/src/components/admin/AdminPostList.tsx
@@ -1,17 +1,42 @@
 'use client';
 
 import Link from 'next/link';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { BlogPost } from '@/data/blog';
 
-export default function AdminPostList({ posts }: { posts: BlogPost[] }) {
+type StatusFilter = 'all' | 'published' | 'draft';
+
+export default function AdminPostList({ posts, staticSlugs = [] }: { posts: BlogPost[]; staticSlugs?: string[] }) {
     const router = useRouter();
     const [deleting, setDeleting] = useState<string | null>(null);
     const [error, setError] = useState<string | null>(null);
+    const [query, setQuery] = useState('');
+    const [status, setStatus] = useState<StatusFilter>('all');
+
+    const staticSet = useMemo(() => new Set(staticSlugs), [staticSlugs]);
+
+    const filtered = useMemo(() => {
+        const q = query.trim().toLowerCase();
+        return posts.filter((post) => {
+            if (status !== 'all' && post.status !== status) return false;
+            if (q && !post.title.toLowerCase().includes(q) && !post.slug.includes(q)) return false;
+            return true;
+        });
+    }, [posts, query, status]);
+
+    const counts = useMemo(() => ({
+        all: posts.length,
+        published: posts.filter((p) => p.status === 'published').length,
+        draft: posts.filter((p) => p.status === 'draft').length,
+    }), [posts]);
 
     const remove = async (slug: string, title: string) => {
-        if (!window.confirm(`Delete "${title}"? This cannot be undone.`)) return;
+        const isOverride = staticSet.has(slug);
+        const message = isOverride
+            ? `Delete the CMS override for "${title}"? The original code-defined article will become live again.`
+            : `Delete "${title}"? This cannot be undone.`;
+        if (!window.confirm(message)) return;
         setDeleting(slug);
         setError(null);
         try {
@@ -39,53 +64,102 @@ export default function AdminPostList({ posts }: { posts: BlogPost[] }) {
     }
 
     return (
-        <div className="space-y-2">
+        <div className="space-y-3">
             {error && (
                 <div role="alert" className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm font-semibold text-red-500">
                     {error}
                 </div>
             )}
-            {posts.map((post) => (
-                <div key={post.slug} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 rounded-xl border border-border bg-background-card px-5 py-4 hover:border-accent/40 transition-colors">
-                    <div className="min-w-0">
-                        <div className="flex items-center gap-2.5 mb-1">
-                            <span
-                                className={`px-2 py-0.5 rounded-full text-[10px] font-black uppercase tracking-wider ${
-                                    post.status === 'published'
-                                        ? 'bg-green-500/10 text-green-500 border border-green-500/30'
-                                        : 'bg-amber-500/10 text-amber-500 border border-amber-500/30'
-                                }`}
-                            >
-                                {post.status}
-                            </span>
-                            <span className="text-xs font-bold text-accent">{post.category}</span>
-                        </div>
-                        <p className="font-bold text-foreground truncate">{post.title}</p>
-                        <p className="text-xs text-foreground-muted mt-0.5">/blog/{post.slug} · {post.date} · {post.readTime}</p>
-                    </div>
-                    <div className="flex items-center gap-2 shrink-0">
-                        {post.status === 'published' && (
-                            <Link href={`/blog/${post.slug}`} target="_blank" className="px-3.5 py-2 rounded-lg text-xs font-bold text-foreground-secondary hover:text-accent transition-colors">
-                                View ↗
-                            </Link>
-                        )}
-                        <Link
-                            href={`/super-admin/posts/${post.slug}/edit`}
-                            className="px-4 py-2 rounded-lg border border-border text-xs font-bold text-foreground hover:border-accent transition-colors"
-                        >
-                            Edit
-                        </Link>
+
+            {/* Toolbar: status tabs + search */}
+            <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-3">
+                <div className="flex gap-1 p-1 rounded-xl bg-background-secondary border border-border w-fit" role="tablist" aria-label="Filter by status">
+                    {(['all', 'published', 'draft'] as const).map((s) => (
                         <button
+                            key={s}
                             type="button"
-                            onClick={() => remove(post.slug, post.title)}
-                            disabled={deleting === post.slug}
-                            className="px-4 py-2 rounded-lg border border-red-500/30 text-xs font-bold text-red-500 hover:bg-red-500/10 transition-colors disabled:opacity-50"
+                            role="tab"
+                            aria-selected={status === s}
+                            onClick={() => setStatus(s)}
+                            className={`px-4 py-1.5 rounded-lg text-xs font-bold capitalize transition-all ${
+                                status === s
+                                    ? 'bg-accent text-white shadow-button'
+                                    : 'text-foreground-secondary hover:text-foreground hover:bg-background-card'
+                            }`}
                         >
-                            {deleting === post.slug ? 'Deleting…' : 'Delete'}
+                            {s === 'draft' ? 'Drafts' : s} <span className={status === s ? 'opacity-80' : 'text-foreground-muted'}>({counts[s]})</span>
                         </button>
-                    </div>
+                    ))}
                 </div>
-            ))}
+                <div className="relative sm:w-72">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="absolute left-3.5 top-1/2 -translate-y-1/2 text-foreground-muted">
+                        <circle cx="11" cy="11" r="8" /><path d="m21 21-4.3-4.3" />
+                    </svg>
+                    <input
+                        type="search"
+                        value={query}
+                        onChange={(e) => setQuery(e.target.value)}
+                        placeholder="Search by title or slug…"
+                        aria-label="Search articles"
+                        className="w-full rounded-xl border border-border bg-background-card pl-10 pr-4 py-2.5 text-sm text-foreground placeholder:text-foreground-muted placeholder:opacity-60 focus:border-accent focus:outline-none transition-colors"
+                    />
+                </div>
+            </div>
+
+            {filtered.length === 0 ? (
+                <div className="rounded-xl border border-dashed border-border bg-background-card/50 px-6 py-10 text-center text-sm text-foreground-secondary">
+                    No articles match {query.trim() ? <>&ldquo;{query.trim()}&rdquo;</> : 'this filter'}.
+                </div>
+            ) : (
+                <div className="space-y-2">
+                    {filtered.map((post) => (
+                        <div key={post.slug} className="flex flex-col sm:flex-row sm:items-center justify-between gap-3 rounded-xl border border-border bg-background-card px-5 py-4 hover:border-accent/40 transition-colors">
+                            <div className="min-w-0">
+                                <div className="flex items-center gap-2.5 mb-1">
+                                    <span
+                                        className={`px-2 py-0.5 rounded-full text-[10px] font-black uppercase tracking-wider ${
+                                            post.status === 'published'
+                                                ? 'bg-green-500/10 text-green-500 border border-green-500/30'
+                                                : 'bg-amber-500/10 text-amber-500 border border-amber-500/30'
+                                        }`}
+                                    >
+                                        {post.status}
+                                    </span>
+                                    {staticSet.has(post.slug) && (
+                                        <span className="px-2 py-0.5 rounded-full text-[10px] font-black uppercase tracking-wider bg-accent/10 text-accent border border-accent/30" title="Replaces the code-defined article with the same slug">
+                                            Override
+                                        </span>
+                                    )}
+                                    <span className="text-xs font-bold text-accent">{post.category}</span>
+                                </div>
+                                <p className="font-bold text-foreground truncate">{post.title}</p>
+                                <p className="text-xs text-foreground-muted mt-0.5">/blog/{post.slug} · {post.date} · {post.readTime}</p>
+                            </div>
+                            <div className="flex items-center gap-2 shrink-0">
+                                {post.status === 'published' && (
+                                    <Link href={`/blog/${post.slug}`} target="_blank" className="px-3.5 py-2 rounded-lg text-xs font-bold text-foreground-secondary hover:text-accent transition-colors">
+                                        View ↗
+                                    </Link>
+                                )}
+                                <Link
+                                    href={`/super-admin/posts/${post.slug}/edit`}
+                                    className="px-4 py-2 rounded-lg border border-border text-xs font-bold text-foreground hover:border-accent transition-colors"
+                                >
+                                    Edit
+                                </Link>
+                                <button
+                                    type="button"
+                                    onClick={() => remove(post.slug, post.title)}
+                                    disabled={deleting === post.slug}
+                                    className="px-4 py-2 rounded-lg border border-red-500/30 text-xs font-bold text-red-500 hover:bg-red-500/10 transition-colors disabled:opacity-50"
+                                >
+                                    {deleting === post.slug ? 'Deleting…' : 'Delete'}
+                                </button>
+                            </div>
+                        </div>
+                    ))}
+                </div>
+            )}
         </div>
     );
 }

--- a/src/components/admin/AdminShell.tsx
+++ b/src/components/admin/AdminShell.tsx
@@ -1,8 +1,20 @@
 import Link from 'next/link';
+import AdminNav from './AdminNav';
 import LogoutButton from './LogoutButton';
 
+interface AdminShellProps {
+    title: string;
+    /** Small muted line under the title. */
+    subtitle?: string;
+    /** Rendered to the right of the title — primary page actions. */
+    actions?: React.ReactNode;
+    children: React.ReactNode;
+}
+
 /** Shared chrome for authenticated super-admin pages. */
-export default function AdminShell({ title, children }: { title: string; children: React.ReactNode }) {
+export default function AdminShell({ title, subtitle, actions, children }: AdminShellProps) {
+    const adminEmail = process.env.ADMIN_EMAIL;
+
     return (
         <div className="min-h-screen">
             <header className="sticky top-0 z-40 border-b border-border bg-background/90 backdrop-blur">
@@ -12,25 +24,30 @@ export default function AdminShell({ title, children }: { title: string; childre
                             <span className="font-extrabold text-lg tracking-tighter text-foreground">BRYNEX</span>
                             <span className="text-[10px] font-black tracking-[0.3em] text-accent uppercase">CMS</span>
                         </Link>
-                        <nav className="hidden sm:flex items-center gap-1 text-sm">
-                            <Link href="/super-admin" className="px-3 py-1.5 rounded-lg text-foreground-secondary hover:text-foreground hover:bg-background-secondary transition-colors font-semibold">
-                                Articles
-                            </Link>
-                            <Link href="/super-admin/posts/new" className="px-3 py-1.5 rounded-lg text-foreground-secondary hover:text-foreground hover:bg-background-secondary transition-colors font-semibold">
-                                New Article
-                            </Link>
-                        </nav>
+                        <AdminNav />
                     </div>
                     <div className="flex items-center gap-3">
-                        <Link href="/blog" target="_blank" className="text-xs font-bold text-foreground-secondary hover:text-accent transition-colors">
+                        <Link href="/blog" target="_blank" className="hidden md:inline text-xs font-bold text-foreground-secondary hover:text-accent transition-colors">
                             View Blog ↗
                         </Link>
+                        {adminEmail && (
+                            <span className="hidden lg:flex items-center gap-2 px-3 py-1.5 rounded-lg bg-background-secondary border border-border text-xs font-semibold text-foreground-secondary" title="Signed in">
+                                <span className="w-1.5 h-1.5 rounded-full bg-green-500" aria-hidden />
+                                {adminEmail}
+                            </span>
+                        )}
                         <LogoutButton />
                     </div>
                 </div>
             </header>
             <main className="mx-auto max-w-7xl px-6 py-10">
-                <h1 className="text-2xl md:text-3xl font-black text-foreground tracking-tight mb-8">{title}</h1>
+                <div className="flex flex-col sm:flex-row sm:items-end justify-between gap-4 mb-8">
+                    <div>
+                        <h1 className="text-2xl md:text-3xl font-black text-foreground tracking-tight">{title}</h1>
+                        {subtitle && <p className="mt-1.5 text-sm text-foreground-secondary">{subtitle}</p>}
+                    </div>
+                    {actions && <div className="shrink-0">{actions}</div>}
+                </div>
                 {children}
             </main>
         </div>

--- a/src/components/admin/LoginForm.tsx
+++ b/src/components/admin/LoginForm.tsx
@@ -8,8 +8,12 @@ export default function LoginForm() {
     const searchParams = useSearchParams();
     const [email, setEmail] = useState('');
     const [password, setPassword] = useState('');
+    const [showPassword, setShowPassword] = useState(false);
     const [error, setError] = useState<string | null>(null);
     const [loading, setLoading] = useState(false);
+
+    const from = searchParams.get('from');
+    const continueTo = from && from.startsWith('/super-admin') && from !== '/super-admin' ? from : null;
 
     const submit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -24,22 +28,30 @@ export default function LoginForm() {
             const data = await res.json();
             if (!res.ok) {
                 setError(data.error ?? 'Login failed.');
+                setLoading(false);
                 return;
             }
-            const from = searchParams.get('from');
+            // Keep the loading state on while navigating so the button doesn't flicker back.
             router.push(from && from.startsWith('/super-admin') ? from : '/super-admin');
             router.refresh();
         } catch {
             setError('Network error — please try again.');
-        } finally {
             setLoading(false);
         }
     };
 
     return (
         <form onSubmit={submit} className="rounded-2xl border border-border bg-background-card p-8 space-y-5 shadow-card">
+            {continueTo && !error && (
+                <div className="rounded-xl border border-accent/20 bg-accent/5 px-4 py-3 text-xs font-semibold text-foreground-secondary">
+                    Sign in to continue to <span className="font-mono text-accent">{continueTo}</span>
+                </div>
+            )}
             {error && (
-                <div role="alert" className="rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm font-semibold text-red-500">
+                <div role="alert" className="flex items-start gap-2.5 rounded-xl border border-red-500/30 bg-red-500/10 px-4 py-3 text-sm font-semibold text-red-500">
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true" className="shrink-0 mt-0.5">
+                        <circle cx="12" cy="12" r="10" /><line x1="12" x2="12" y1="8" y2="12" /><line x1="12" x2="12.01" y1="16" y2="16" />
+                    </svg>
                     {error}
                 </div>
             )}
@@ -49,29 +61,55 @@ export default function LoginForm() {
                     id="admin-email"
                     type="email"
                     required
+                    autoFocus
                     autoComplete="username"
+                    placeholder="you@brynex.in"
                     value={email}
                     onChange={(e) => setEmail(e.target.value)}
-                    className="w-full rounded-xl border border-border bg-background px-4 py-3 text-foreground focus:border-accent focus:outline-none transition-colors"
+                    className="w-full rounded-xl border border-border bg-background px-4 py-3 text-foreground placeholder:text-foreground-muted placeholder:opacity-50 focus:border-accent focus:outline-none transition-colors"
                 />
             </div>
             <div>
                 <label htmlFor="admin-password" className="block text-xs font-black uppercase tracking-widest text-foreground-secondary mb-2">Password</label>
-                <input
-                    id="admin-password"
-                    type="password"
-                    required
-                    autoComplete="current-password"
-                    value={password}
-                    onChange={(e) => setPassword(e.target.value)}
-                    className="w-full rounded-xl border border-border bg-background px-4 py-3 text-foreground focus:border-accent focus:outline-none transition-colors"
-                />
+                <div className="relative">
+                    <input
+                        id="admin-password"
+                        type={showPassword ? 'text' : 'password'}
+                        required
+                        autoComplete="current-password"
+                        placeholder="••••••••"
+                        value={password}
+                        onChange={(e) => setPassword(e.target.value)}
+                        className="w-full rounded-xl border border-border bg-background px-4 py-3 pr-12 text-foreground placeholder:text-foreground-muted placeholder:opacity-50 focus:border-accent focus:outline-none transition-colors"
+                    />
+                    <button
+                        type="button"
+                        onClick={() => setShowPassword((v) => !v)}
+                        aria-label={showPassword ? 'Hide password' : 'Show password'}
+                        className="absolute right-3 top-1/2 -translate-y-1/2 p-1 text-foreground-muted hover:text-foreground transition-colors"
+                    >
+                        {showPassword ? (
+                            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                                <path d="M10.733 5.076a10.744 10.744 0 0 1 11.205 6.575 1 1 0 0 1 0 .696 10.747 10.747 0 0 1-1.444 2.49" /><path d="M14.084 14.158a3 3 0 0 1-4.242-4.242" /><path d="M17.479 17.499a10.75 10.75 0 0 1-15.417-5.151 1 1 0 0 1 0-.696 10.75 10.75 0 0 1 4.446-5.143" /><line x1="2" x2="22" y1="2" y2="22" />
+                            </svg>
+                        ) : (
+                            <svg width="17" height="17" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+                                <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7-10-7-10-7Z" /><circle cx="12" cy="12" r="3" />
+                            </svg>
+                        )}
+                    </button>
+                </div>
             </div>
             <button
                 type="submit"
                 disabled={loading}
-                className="w-full py-3 rounded-xl bg-accent-gradient text-white font-bold shadow-button hover:brightness-110 transition-all disabled:opacity-50"
+                className="w-full flex items-center justify-center gap-2.5 py-3 rounded-xl bg-accent-gradient text-white font-bold shadow-button hover:brightness-110 transition-all disabled:opacity-60 disabled:cursor-not-allowed"
             >
+                {loading && (
+                    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" aria-hidden="true" className="animate-spin">
+                        <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+                    </svg>
+                )}
                 {loading ? 'Signing in…' : 'Sign In'}
             </button>
         </form>

--- a/src/components/admin/PostEditor.tsx
+++ b/src/components/admin/PostEditor.tsx
@@ -8,7 +8,8 @@ import RichTextEditor from './RichTextEditor';
 import ArticleProse from '@/components/blog/ArticleProse';
 
 interface PostEditorProps {
-    mode: 'create' | 'edit';
+    /** 'override' edits a code-defined article: saving creates a CMS copy that takes precedence. */
+    mode: 'create' | 'edit' | 'override';
     initialPost?: BlogPost;
 }
 
@@ -34,7 +35,7 @@ export default function PostEditor({ mode, initialPost }: PostEditorProps) {
 
     const [title, setTitle] = useState(initialPost?.title ?? '');
     const [slug, setSlug] = useState(initialPost?.slug ?? '');
-    const [slugTouched, setSlugTouched] = useState(mode === 'edit');
+    const [slugTouched, setSlugTouched] = useState(mode !== 'create');
     const [excerpt, setExcerpt] = useState(initialPost?.excerpt ?? '');
     const [author, setAuthor] = useState(initialPost?.author ?? 'Brynex Labs Engineering');
     const [category, setCategory] = useState<BlogCategory>(initialPost?.category ?? 'Engineering');
@@ -91,6 +92,8 @@ export default function PostEditor({ mode, initialPost }: PostEditorProps) {
             relatedServices,
             techTags,
             status,
+            // Overriding a code-defined article reuses its slug on purpose.
+            overrideStatic: mode === 'override',
         };
 
         try {
@@ -133,6 +136,12 @@ export default function PostEditor({ mode, initialPost }: PostEditorProps) {
         <div className="grid grid-cols-1 xl:grid-cols-[1fr_360px] gap-8 items-start">
             {/* ===== Main column ===== */}
             <div className="space-y-6 min-w-0">
+                {mode === 'override' && (
+                    <div className="rounded-xl border border-amber-500/30 bg-amber-500/10 px-5 py-4 text-sm text-foreground-secondary">
+                        <span className="font-bold text-amber-500">Code-defined article.</span>{' '}
+                        Saving creates a CMS copy that replaces the original on the live site. Deleting the CMS copy later restores the code-defined version.
+                    </div>
+                )}
                 {error && (
                     <div role="alert" className="rounded-xl border border-red-500/30 bg-red-500/10 px-5 py-4 text-sm font-semibold text-red-500">
                         {error}
@@ -240,7 +249,7 @@ export default function PostEditor({ mode, initialPost }: PostEditorProps) {
                             disabled={saving}
                             className="w-full py-3 rounded-xl bg-accent-gradient text-white font-bold shadow-button hover:brightness-110 transition-all disabled:opacity-50"
                         >
-                            {saving ? 'Saving…' : mode === 'edit' ? 'Update & Publish' : 'Publish Article'}
+                            {saving ? 'Saving…' : mode === 'edit' ? 'Update & Publish' : mode === 'override' ? 'Publish Override' : 'Publish Article'}
                         </button>
                         <button
                             type="button"
@@ -265,9 +274,13 @@ export default function PostEditor({ mode, initialPost }: PostEditorProps) {
                                 value={slug}
                                 onChange={(e) => { setSlug(slugify(e.target.value)); setSlugTouched(true); }}
                                 placeholder="your-article-slug"
-                                className={`${FIELD_CLASS} !py-2 font-mono text-sm`}
+                                disabled={mode === 'override'}
+                                className={`${FIELD_CLASS} !py-2 font-mono text-sm disabled:opacity-60 disabled:cursor-not-allowed`}
                             />
                         </div>
+                        {mode === 'override' && (
+                            <p className="mt-1.5 text-xs text-foreground-muted">Locked — the override must keep the original URL to replace it.</p>
+                        )}
                     </div>
                     <div>
                         <label htmlFor="post-author" className={LABEL_CLASS}>Author</label>

--- a/src/lib/blogService.ts
+++ b/src/lib/blogService.ts
@@ -16,7 +16,11 @@ export async function getAllPosts(): Promise<BlogPost[]> {
         // The blog must stay up even if the database is unreachable.
         console.error('[blog] Failed to load posts from MongoDB:', err);
     }
-    const statics = staticPosts.map((p) => ({ ...p, source: 'static' as const }));
+    // A published DB post with the same slug overrides its code-defined original.
+    const dbSlugs = new Set(dbPosts.map((p) => p.slug));
+    const statics = staticPosts
+        .filter((p) => !dbSlugs.has(p.slug))
+        .map((p) => ({ ...p, source: 'static' as const }));
     return [...dbPosts, ...statics].sort((a, b) => postTime(b) - postTime(a));
 }
 

--- a/src/lib/blogStore.ts
+++ b/src/lib/blogStore.ts
@@ -172,8 +172,10 @@ export function isStaticSlug(slug: string): boolean {
     return staticPosts.some((p) => p.slug === slug);
 }
 
-export async function createDbPost(input: BlogPostInput): Promise<BlogPost> {
-    if (isStaticSlug(input.slug)) {
+export async function createDbPost(input: BlogPostInput, options?: { allowStaticSlug?: boolean }): Promise<BlogPost> {
+    // A DB post sharing a static slug acts as an override: getPostBySlug prefers
+    // the DB version, so the CMS copy replaces the code-defined article publicly.
+    if (!options?.allowStaticSlug && isStaticSlug(input.slug)) {
         throw new Error('This slug is already used by a code-defined article.');
     }
     const col = await collection();

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -6,11 +6,18 @@ const PUBLIC_ADMIN_PATHS = ['/super-admin/login', '/api/admin/login'];
 export async function middleware(request: NextRequest) {
     const { pathname } = request.nextUrl;
 
+    const token = request.cookies.get(ADMIN_COOKIE)?.value;
+
     if (PUBLIC_ADMIN_PATHS.includes(pathname)) {
+        // Already signed in — skip the login screen and land on the dashboard.
+        if (pathname === '/super-admin/login' && (await verifySessionToken(token))) {
+            const from = request.nextUrl.searchParams.get('from');
+            const target = from && from.startsWith('/super-admin') ? from : '/super-admin';
+            return NextResponse.redirect(new URL(target, request.url));
+        }
         return NextResponse.next();
     }
 
-    const token = request.cookies.get(ADMIN_COOKIE)?.value;
     const isAuthenticated = await verifySessionToken(token);
 
     if (isAuthenticated) {


### PR DESCRIPTION


Login & access flow:
- Middleware now redirects already-authenticated users away from /super-admin/login straight to the dashboard (honoring ?from=).
- Redesigned login page: lock badge, accent glow + grid backdrop, back-to-website link, restricted-area footnote.
- LoginForm: email autofocus, show/hide password toggle, spinner that persists through redirect, icon error states, and a "sign in to continue to <page>" hint when bounced from a protected page.
- Footer: Admin link moved out of the Legal column into the bottom bar as a discreet lock-icon link beside the theme toggle.

Admin dashboard:
- New AdminNav client component with active-state highlighting.
- AdminShell: signed-in email chip, subtitle + actions slot; the "+ New Article" CTA now lives in the page header.
- Stat cards (CMS articles / published / drafts / code-defined).
- AdminPostList: status filter tabs with counts, title/slug search, empty-state for filtered results.

CMS overrides for code-defined articles:
- Editing a code-defined article opens the full PostEditor pre-filled and saves a DB copy with the same slug (explicit overrideStatic flag; slug locked in override mode). getPostBySlug already prefers DB posts, so the override replaces the original publicly.
- getAllPosts dedupes statics that have a DB override.
- Dashboard marks overridden originals; the CMS copy gets an Override chip and a delete-confirm that explains the original will be restored.
- POST /api/admin/posts returns 409 on static-slug reuse unless the override flag is set.

Verified: tsc, eslint, next build, plus live smoke tests of the auth redirect flow and the full override create/render/dedupe/delete cycle.