### PR TITLE
feat(admin): serve the admin panel on admin.<domain> via host-based middleware routing

### DIFF
--- a/src/app/super-admin/login/page.tsx
+++ b/src/app/super-admin/login/page.tsx
@@ -1,8 +1,14 @@
 import { Suspense } from 'react';
 import Link from 'next/link';
+import { headers } from 'next/headers';
 import LoginForm from '@/components/admin/LoginForm';
 
 export default function AdminLoginPage() {
+    // On admin.<domain> "/" is the dashboard, so "Back to website" must
+    // point at the main site instead.
+    const host = headers().get('host') ?? '';
+    const backHref = host.startsWith('admin.') ? `https://${host.replace(/^admin\./, '')}` : '/';
+
     return (
         <div className="relative min-h-screen flex items-center justify-center px-6 py-16 overflow-hidden">
             {/* Decorative backdrop */}
@@ -21,7 +27,7 @@ export default function AdminLoginPage() {
             </div>
 
             <Link
-                href="/"
+                href={backHref}
                 className="absolute top-6 left-6 z-10 flex items-center gap-2 text-sm font-semibold text-foreground-secondary hover:text-foreground transition-colors"
             >
                 <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">

--- a/src/components/admin/AdminSidebar.tsx
+++ b/src/components/admin/AdminSidebar.tsx
@@ -33,18 +33,18 @@ const ICONS = {
     ),
 };
 
-const SECTIONS: { label: string; items: { href: string; label: string; icon: keyof typeof ICONS; badge?: 'leads' }[] }[] = [
+const SECTIONS: { label: string; items: { sub: string; label: string; icon: keyof typeof ICONS; badge?: 'leads' }[] }[] = [
     {
         label: 'Content',
         items: [
-            { href: '/super-admin', label: 'Articles', icon: 'articles' },
-            { href: '/super-admin/posts/new', label: 'New Article', icon: 'newArticle' },
+            { sub: '', label: 'Articles', icon: 'articles' },
+            { sub: '/posts/new', label: 'New Article', icon: 'newArticle' },
         ],
     },
     {
         label: 'Engagement',
         items: [
-            { href: '/super-admin/leads', label: 'Leads', icon: 'leads', badge: 'leads' },
+            { sub: '/leads', label: 'Leads', icon: 'leads', badge: 'leads' },
         ],
     },
 ];
@@ -53,10 +53,15 @@ export default function AdminSidebar({ newLeads = 0, adminEmail }: AdminSidebarP
     const pathname = usePathname();
     const [drawerOpen, setDrawerOpen] = useState(false);
 
-    const isActive = (href: string) =>
-        href === '/super-admin'
-            ? pathname === '/super-admin' || pathname.startsWith('/super-admin/posts/') && pathname.endsWith('/edit')
-            : pathname === href;
+    // On admin.<domain> the URLs are clean ("/leads"); in dev/preview they
+    // live under /super-admin. Derive the base from the current path so
+    // links and active states work on both without hydration mismatches.
+    const base = pathname?.startsWith('/super-admin') ? '/super-admin' : '';
+    const hrefFor = (sub: string) => `${base}${sub}` || '/';
+    const isActive = (sub: string) =>
+        sub === ''
+            ? pathname === (base || '/') || (pathname.includes('/posts/') && pathname.endsWith('/edit'))
+            : pathname === `${base}${sub}`;
 
     const nav = (
         <nav className="flex-1 px-3 py-5 space-y-6 overflow-y-auto">
@@ -65,11 +70,11 @@ export default function AdminSidebar({ newLeads = 0, adminEmail }: AdminSidebarP
                     <p className="px-3 mb-2 text-[10px] font-black uppercase tracking-[0.2em] text-foreground-muted">{section.label}</p>
                     <div className="space-y-1">
                         {section.items.map((item) => {
-                            const active = isActive(item.href);
+                            const active = isActive(item.sub);
                             return (
                                 <Link
-                                    key={item.href}
-                                    href={item.href}
+                                    key={item.sub || 'articles'}
+                                    href={hrefFor(item.sub)}
                                     onClick={() => setDrawerOpen(false)}
                                     aria-current={active ? 'page' : undefined}
                                     className={`group relative flex items-center gap-3 px-3 py-2.5 rounded-xl text-sm font-semibold transition-all duration-200 ${
@@ -121,7 +126,7 @@ export default function AdminSidebar({ newLeads = 0, adminEmail }: AdminSidebarP
     );
 
     const brand = (
-        <Link href="/super-admin" className="flex items-baseline gap-2 select-none" onClick={() => setDrawerOpen(false)}>
+        <Link href={hrefFor('')} className="flex items-baseline gap-2 select-none" onClick={() => setDrawerOpen(false)}>
             <span className="font-extrabold text-lg tracking-tighter text-foreground">BRYNEX</span>
             <span className="text-[10px] font-black tracking-[0.3em] text-accent uppercase">CMS</span>
         </Link>

--- a/src/components/admin/LoginForm.tsx
+++ b/src/components/admin/LoginForm.tsx
@@ -13,7 +13,8 @@ export default function LoginForm() {
     const [loading, setLoading] = useState(false);
 
     const from = searchParams.get('from');
-    const continueTo = from && from.startsWith('/super-admin') && from !== '/super-admin' ? from : null;
+    const safeFrom = from && from.startsWith('/') && !from.startsWith('//') ? from : null;
+    const continueTo = safeFrom && safeFrom !== '/super-admin' && safeFrom !== '/' ? safeFrom : null;
 
     const submit = async (e: React.FormEvent) => {
         e.preventDefault();
@@ -32,7 +33,9 @@ export default function LoginForm() {
                 return;
             }
             // Keep the loading state on while navigating so the button doesn't flicker back.
-            router.push(from && from.startsWith('/super-admin') ? from : '/super-admin');
+            // On admin.<domain> the dashboard is "/"; in dev/preview it's /super-admin.
+            const fallback = window.location.hostname.startsWith('admin.') ? '/' : '/super-admin';
+            router.push(safeFrom ?? fallback);
             router.refresh();
         } catch {
             setError('Network error — please try again.');

--- a/src/components/admin/LogoutButton.tsx
+++ b/src/components/admin/LogoutButton.tsx
@@ -1,13 +1,16 @@
 'use client';
 
-import { useRouter } from 'next/navigation';
+import { useRouter, usePathname } from 'next/navigation';
 
 export default function LogoutButton() {
     const router = useRouter();
+    const pathname = usePathname();
 
     const logout = async () => {
         await fetch('/api/admin/logout', { method: 'POST' });
-        router.push('/super-admin/login');
+        // Clean URLs on admin.<domain>, /super-admin paths in dev/preview.
+        const base = pathname?.startsWith('/super-admin') ? '/super-admin' : '';
+        router.push(`${base}/login`);
         router.refresh();
     };
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,38 +1,145 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { ADMIN_COOKIE, verifySessionToken } from '@/lib/adminSession';
 
-const PUBLIC_ADMIN_PATHS = ['/super-admin/login', '/api/admin/login'];
+const ADMIN_PREFIX = '/super-admin';
+const ROOT_DOMAIN = process.env.NEXT_PUBLIC_ROOT_DOMAIN ?? 'brynex.in';
 
+/** Page paths that exist on the admin subdomain (clean URLs, no /super-admin prefix). */
+const ADMIN_PAGE_PREFIXES = ['/login', '/leads', '/posts'];
+
+function isStaticAsset(pathname: string): boolean {
+    return (
+        pathname.startsWith('/_next') ||
+        pathname.startsWith('/fonts') ||
+        /\.[a-zA-Z0-9]+$/.test(pathname) // favicon.ico, robots.txt, images, …
+    );
+}
+
+function isAdminPagePath(pathname: string): boolean {
+    return (
+        pathname === '/' ||
+        ADMIN_PAGE_PREFIXES.some((p) => pathname === p || pathname.startsWith(`${p}/`))
+    );
+}
+
+/**
+ * Host-based routing:
+ *  - admin.<domain> serves the admin app at clean URLs ("/", "/leads",
+ *    "/posts/new", "/login") by rewriting onto /super-admin/* internally.
+ *  - The apex/www domain redirects /super-admin/* over to the subdomain.
+ *  - Any other host (localhost dev, previews) keeps the classic
+ *    /super-admin paths so local workflows are unchanged.
+ */
 export async function middleware(request: NextRequest) {
     const { pathname } = request.nextUrl;
+    const host = (request.headers.get('host') ?? '').toLowerCase();
+    const hostname = host.split(':')[0];
+    const isAdminHost = hostname.startsWith('admin.');
 
-    const token = request.cookies.get(ADMIN_COOKIE)?.value;
+    if (isAdminHost) {
+        if (isStaticAsset(pathname)) return NextResponse.next();
 
-    if (PUBLIC_ADMIN_PATHS.includes(pathname)) {
-        // Already signed in — skip the login screen and land on the dashboard.
-        if (pathname === '/super-admin/login' && (await verifySessionToken(token))) {
-            const from = request.nextUrl.searchParams.get('from');
-            const target = from && from.startsWith('/super-admin') ? from : '/super-admin';
-            return NextResponse.redirect(new URL(target, request.url));
+        // Only the admin API belongs on this host.
+        if (pathname.startsWith('/api/') && !pathname.startsWith('/api/admin')) {
+            return NextResponse.json({ error: 'Not found' }, { status: 404 });
         }
-        return NextResponse.next();
+
+        // Normalize legacy/internal links: /super-admin/leads -> /leads
+        if (pathname.startsWith(ADMIN_PREFIX)) {
+            const url = request.nextUrl.clone();
+            url.pathname = pathname.slice(ADMIN_PREFIX.length) || '/';
+            return NextResponse.redirect(url);
+        }
+
+        // Non-admin pages (e.g. /blog) belong on the main site.
+        if (!pathname.startsWith('/api/admin') && !isAdminPagePath(pathname)) {
+            const url = request.nextUrl.clone();
+            url.host = host.replace(/^admin\./, '');
+            return NextResponse.redirect(url);
+        }
+
+        const token = request.cookies.get(ADMIN_COOKIE)?.value;
+        const isAuthenticated = await verifySessionToken(token);
+
+        // Public endpoints: the login screen and the login API.
+        if (pathname === '/login' || pathname === '/api/admin/login') {
+            if (pathname === '/login') {
+                if (isAuthenticated) {
+                    const from = request.nextUrl.searchParams.get('from');
+                    const url = request.nextUrl.clone();
+                    url.pathname = from && from.startsWith('/') && !from.startsWith('//') ? from : '/';
+                    url.search = '';
+                    return NextResponse.redirect(url);
+                }
+                const url = request.nextUrl.clone();
+                url.pathname = `${ADMIN_PREFIX}/login`;
+                return NextResponse.rewrite(url);
+            }
+            return NextResponse.next();
+        }
+
+        if (!isAuthenticated) {
+            if (pathname.startsWith('/api/admin')) {
+                return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+            }
+            const url = request.nextUrl.clone();
+            url.pathname = '/login';
+            url.search = '';
+            url.searchParams.set('from', pathname);
+            return NextResponse.redirect(url);
+        }
+
+        if (pathname.startsWith('/api/admin')) return NextResponse.next();
+
+        // Authenticated page: serve the real route under /super-admin.
+        const url = request.nextUrl.clone();
+        url.pathname = pathname === '/' ? ADMIN_PREFIX : `${ADMIN_PREFIX}${pathname}`;
+        return NextResponse.rewrite(url);
     }
 
-    const isAuthenticated = await verifySessionToken(token);
+    // ----- Main domain / other hosts -----
 
-    if (isAuthenticated) {
-        return NextResponse.next();
+    // In production the admin lives on the subdomain — move old URLs there.
+    if (
+        pathname.startsWith(ADMIN_PREFIX) &&
+        (hostname === ROOT_DOMAIN || hostname === `www.${ROOT_DOMAIN}`)
+    ) {
+        const url = request.nextUrl.clone();
+        url.host = `admin.${ROOT_DOMAIN}`;
+        url.pathname = pathname.slice(ADMIN_PREFIX.length) || '/';
+        return NextResponse.redirect(url);
     }
 
-    if (pathname.startsWith('/api/admin')) {
-        return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    // Classic /super-admin behavior (local dev, preview deployments).
+    if (pathname.startsWith(ADMIN_PREFIX) || pathname.startsWith('/api/admin')) {
+        const token = request.cookies.get(ADMIN_COOKIE)?.value;
+
+        if (pathname === `${ADMIN_PREFIX}/login` || pathname === '/api/admin/login') {
+            if (pathname === `${ADMIN_PREFIX}/login` && (await verifySessionToken(token))) {
+                const from = request.nextUrl.searchParams.get('from');
+                const target = from && from.startsWith(ADMIN_PREFIX) ? from : ADMIN_PREFIX;
+                return NextResponse.redirect(new URL(target, request.url));
+            }
+            return NextResponse.next();
+        }
+
+        const isAuthenticated = await verifySessionToken(token);
+        if (isAuthenticated) return NextResponse.next();
+
+        if (pathname.startsWith('/api/admin')) {
+            return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+        }
+
+        const loginUrl = new URL(`${ADMIN_PREFIX}/login`, request.url);
+        loginUrl.searchParams.set('from', pathname);
+        return NextResponse.redirect(loginUrl);
     }
 
-    const loginUrl = new URL('/super-admin/login', request.url);
-    loginUrl.searchParams.set('from', pathname);
-    return NextResponse.redirect(loginUrl);
+    return NextResponse.next();
 }
 
 export const config = {
-    matcher: ['/super-admin/:path*', '/api/admin/:path*'],
+    // Host-based routing needs to see every request; static assets are
+    // filtered both here and in isStaticAsset() for the admin host.
+    matcher: ['/((?!_next/static|_next/image|favicon.ico|fonts).*)'],
 };


### PR DESCRIPTION


One app, two hosts. The middleware now routes by Host header:

admin.<domain> (e.g. admin.brynex.in):
- Clean URLs — "/", "/leads", "/posts/new", "/login" — rewritten internally onto the existing /super-admin routes; /api/admin/* works as-is. Auth redirects use the clean /login path (?from= preserved).
- /super-admin/* links are normalized to their clean equivalents, so server-rendered legacy links keep working via one redirect hop.
- Non-admin pages (e.g. /blog) and non-admin APIs are pushed back to the main domain / 404'd, so the subdomain only exposes the panel.

Main domain:
- brynex.in and www.brynex.in redirect /super-admin/* to the subdomain (path translated to the clean form).
- Any other host (localhost, previews) keeps classic /super-admin behavior, so local dev is unchanged.

Host-aware UI (derived from usePathname/host — no hydration risk):
- AdminSidebar builds links and active states from a base prefix that is "/super-admin" in dev and "" on the subdomain.
- LoginForm validates ?from= as a safe relative path and falls back to "/" on the subdomain vs /super-admin elsewhere; LogoutButton returns to the right login URL; the login page's "Back to website" link points at the main domain when on admin.<domain>.

Root domain is configurable via NEXT_PUBLIC_ROOT_DOMAIN (defaults to brynex.in). Verified with Host-header tests against the running app: unauth redirect to /login, login page render, authenticated "/", "/leads", "/posts/new" all 200 with correct content, authed /login redirects to "/", /super-admin/leads normalizes to /leads, /blog bounces to the main domain, /api/contact 404s on the subdomain, www.brynex.in/super-admin/leads redirects to admin.brynex.in/leads, and localhost dev flow is unchanged.