### PR TITLE
feat(seo): full on-page SEO overhaul, geo-routed India service pages, AI-search readiness

### DIFF
--- a/docs/seo/KEYWORD-STRATEGY.md
+++ b/docs/seo/KEYWORD-STRATEGY.md
@@ -1,0 +1,114 @@
+# Brynex Labs — Keyword Strategy (USA + India)
+
+> Companion to `OFF-PAGE-SEO-PLAYBOOK.md`. This maps every target keyword to a page,
+> intent stage, and market. Review quarterly; refresh volumes/difficulty in Ahrefs or Semrush.
+> Last updated: June 2026.
+
+## Positioning summary
+
+Brynex Labs sells three things. Every keyword below ladders up to one of them:
+
+1. **Agentic AI & Intelligent Automation** → `/services/ai-agents-automation`
+2. **AI-Native Software Engineering (custom software / SaaS)** → `/services/ai-native-software-engineering`
+3. **SaaS SEO for B2B companies** → `/services/saas-seo`
+
+Strategic insight from research: in 2026, **buyer-intent ("hire", "company", "services",
+"pricing", "cost") keywords beat high-volume head terms** for lead generation, and AI-search
+(Google AI Overviews, ChatGPT, Perplexity) citations convert ~5x better than classic organic.
+Structured, specific, commercially useful pages win both.
+
+---
+
+## Primary money keywords (BOFU — these generate leads)
+
+### Pillar 1 — AI Agents & Automation
+
+| Keyword | Market | Intent | Target page |
+|---|---|---|---|
+| AI agent development company | US + IN | BOFU | /services/ai-agents-automation |
+| AI agent development services | US + IN | BOFU | /services/ai-agents-automation |
+| agentic AI development | US | BOFU | /services/ai-agents-automation |
+| AI automation agency | US + IN | BOFU | /services/ai-agents-automation |
+| custom AI agent development | US | BOFU | /services/ai-agents-automation |
+| RAG development services | US | BOFU | /services/ai-agents-automation |
+| LLM development company | US + IN | BOFU | /services/ai-agents-automation |
+| enterprise AI automation services | US | BOFU | /services/ai-agents-automation |
+| hire AI developers | US + IN | BOFU | /hire-ai-developers |
+| hire AI engineers India | US + IN | BOFU | /hire-ai-developers |
+| dedicated AI development team | US | BOFU | /hire-ai-developers |
+| AI agent development cost | US + IN | BOFU/MOFU | service FAQ (answered) |
+
+### Pillar 2 — Custom Software / SaaS Engineering
+
+| Keyword | Market | Intent | Target page |
+|---|---|---|---|
+| custom software development company | US + IN | BOFU | /services/ai-native-software-engineering |
+| SaaS development company | US + IN | BOFU | /services/ai-native-software-engineering |
+| offshore software development company India | US | BOFU | /ai-development-company-in-india |
+| AI development company in India | US + IN | BOFU | /ai-development-company-in-india |
+| software development company in India | US + IN | BOFU | /ai-development-company-in-india |
+| web application development services | US + IN | BOFU | /services/ai-native-software-engineering |
+| MVP development company | US + IN | BOFU | /services/ai-native-software-engineering |
+| application modernization services | US | BOFU | /services/ai-native-software-engineering |
+| custom software development cost | US + IN | MOFU | service FAQ (answered) |
+
+### Pillar 3 — SaaS SEO
+
+| Keyword | Market | Intent | Target page |
+|---|---|---|---|
+| SaaS SEO agency | US + IN | BOFU | /services/saas-seo |
+| B2B SaaS SEO services | US | BOFU | /services/saas-seo |
+| SEO for SaaS companies | US + IN | BOFU/MOFU | /services/saas-seo |
+| SaaS SEO consultant | US | BOFU | /services/saas-seo |
+| programmatic SEO services | US | BOFU | /services/saas-seo |
+| SaaS SEO agency India | IN | BOFU | /services/saas-seo |
+
+---
+
+## Supporting keywords (MOFU/TOFU — blog content engine)
+
+Publish via the Super Admin CMS (`/super-admin`). Each post must link to its money page
+and end with a service CTA. Target cadence: **2 posts/month minimum.**
+
+### AI pillar cluster (link to /services/ai-agents-automation)
+- "AI agents vs chatbots: what businesses actually need" (comparison — high AI-Overview citation potential)
+- "How much does it cost to build an AI agent in 2026" (pricing content ranks + converts)
+- "LangChain vs LangGraph vs CrewAI: production comparison"
+- "RAG architecture guide: vector databases compared (Pinecone vs Qdrant vs pgvector)"
+- "AI agent ROI: how to measure automation savings"
+- "AI customer support automation: implementation guide"
+
+### Software pillar cluster (link to /services/ai-native-software-engineering)
+- "In-house vs outsourced software development: 2026 cost analysis"
+- "How to choose a custom software development company (checklist)"
+- "Offshore development to India: complete guide for US founders"
+- "MVP development timeline: what 8–12 weeks actually looks like"
+- "Multi-tenant SaaS architecture: a practical guide"
+
+### SaaS SEO pillar cluster (link to /services/saas-seo)
+- "BOFU keywords for SaaS: how to find them"
+- "Programmatic SEO for SaaS: templates and pitfalls"
+- "SaaS SEO vs paid ads: CAC comparison"
+- "How B2B SaaS gets cited in AI Overviews / ChatGPT (GEO guide)"
+
+---
+
+## Title/meta conventions (applied on-page)
+
+- Titles ≤ 60 chars, primary keyword **first**, brand last: `AI Agent Development Company | …`
+- Descriptions 140–160 chars, include keyword + geo (USA & India) + a concrete hook (price, speed, outcome).
+- One H1 per page containing the primary keyword. H2s carry secondary keywords.
+- Every service/landing page carries: `Service` + `BreadcrumbList` + `FAQPage` JSON-LD.
+- FAQs must answer **price and geography questions verbatim** — these are the queries AI engines cite.
+
+## Geo strategy
+
+- **USA (revenue market):** lead with outcomes + cost advantage ("40–60% below US rates"), US-style trust signals (NDA, IP transfer, timezone overlap). USD pricing on pages.
+- **India (volume + local market):** `/ai-development-company-in-india` is the geo hub. Footer states "Based in India · Working Globally". Add city pages (Bangalore, Pune, Delhi NCR) ONLY if/when a physical presence or GBP listing exists — never fake locations.
+- `Organization.areaServed` schema lists US, IN, UK, AU, CA on the homepage.
+
+## Measurement
+
+- GSC: track query → page mapping monthly; flag any money keyword stuck on page 2 (those get the off-page push first).
+- GA4: organic sessions → contact-form conversions per landing page (events already wired via `src/lib/tracking.ts`).
+- Rank tracking: set up the BOFU tables above in Ahrefs/Semrush with US and IN locations separately.

--- a/docs/seo/OFF-PAGE-SEO-PLAYBOOK.md
+++ b/docs/seo/OFF-PAGE-SEO-PLAYBOOK.md
@@ -1,0 +1,151 @@
+# Brynex Labs — Off-Page SEO Playbook
+
+> The implementation guide for everything that happens **off** brynex.in: authority building,
+> backlinks, directories, digital PR, and AI-search (GEO) visibility — for both the **USA** and
+> **India** markets. Work through it top-to-bottom; Phase 1 items compound the longest.
+> Companion doc: `KEYWORD-STRATEGY.md`. Last updated: June 2026.
+
+---
+
+## How to use this playbook
+
+- Each task has a checkbox — track progress directly in this file via PRs.
+- Cadence: **Phase 1 = weeks 1–4**, **Phase 2 = months 2–3**, **Phase 3 = months 3–6**, then ongoing.
+- One owner per phase. Most tasks take < 2 hours; consistency beats intensity.
+- Golden rule: **never buy bulk links, never use PBNs, never spin content.** One DR-60 editorial
+  link from a relevant tech publication outranks 100 directory spam links and carries zero penalty risk.
+
+---
+
+## Phase 1 — Foundation (Weeks 1–4): claim every free authority signal
+
+### 1.1 Google & Bing essentials
+- [ ] **Google Business Profile** (critical for "AI development company in India" map-pack):
+      create for the India registered address, category "Software Company", services list matching
+      the 3 service pages, weekly posts, photos of team/workspace. Link to https://brynex.in.
+- [ ] **Bing Places** + **Bing Webmaster Tools** (Bing powers ChatGPT browsing — this is a GEO play, not just Bing SEO).
+- [ ] Verify GSC property is on the **domain level** (covers www + subdomains).
+
+### 1.2 B2B service directories (highest-converting backlinks in this industry)
+These rank on page 1 for almost every "best AI development company" query — being listed
+**is** ranking. Complete profiles with case studies, exact service names, and pricing bands.
+
+| Directory | Priority | Notes |
+|---|---|---|
+| [ ] Clutch.co | P0 | The single highest-ROI listing. Get 3–5 verified client reviews (Echopad, CloudScale). Target "AI Development — India" + "Custom Software — India" categories. |
+| [ ] GoodFirms | P0 | Free listing, strong for India dev companies. |
+| [ ] DesignRush | P1 | Free, accepts agency profiles, gives a followed link. |
+| [ ] G2 (Services) | P1 | US buyer audience. |
+| [ ] Wellfound (AngelList) | P1 | Startup-buyer audience + careers page synergy. |
+| [ ] TechBehemoths | P2 | Free, EU/US traffic. |
+| [ ] F6S, Crunchbase | P2 | Crunchbase profile also feeds AI/LLM knowledge graphs. |
+| [ ] Upwork/Toptal agency profile | P2 | Optional lead channel; links are nofollow but profile ranks. |
+
+### 1.3 Social & entity consistency (knowledge-graph hygiene)
+Google and LLMs cross-reference entities. Identical NAP (name, description, services) everywhere:
+- [ ] LinkedIn company page: keyword-rich tagline ("AI Agent Development & Custom Software Company"), services section filled, weekly posting.
+- [ ] X/Twitter bio aligned; pin a case-study thread.
+- [ ] GitHub org (brynexlabs): pin 2–3 real OSS repos (see §3.4) — engineers and LLMs both read GitHub.
+- [ ] YouTube channel (even 3–4 videos: case study walkthroughs, "how we build agents") — video results rank for "AI agent development" queries.
+- [ ] Add the same canonical company description (50 words) to every profile. Keep a copy in this repo: `docs/seo/boilerplate.md`.
+
+### 1.4 Review generation engine
+- [ ] Email the 25+ past clients; ask the 5 happiest for Clutch + Google reviews (offer a 15-min call to make it easy).
+- [ ] Add a post-project step in the delivery process: "request review" (bake into how-we-work checklist).
+- [ ] Display review badges on the site once ≥ 5 reviews exist (social proof → conversion lift).
+
+---
+
+## Phase 2 — Authority content & digital PR (Months 2–3)
+
+### 2.1 Guest posting (quality over volume; 2/month)
+Targets where Brynex's expertise is genuinely useful (pitch the **engineer's** byline, not "marketing"):
+- Dev-audience: dev.to, Hashnode, freeCodeCamp News, The New Stack, InfoQ (editorial), DZone.
+- Business-audience: HackerNoon, TechBullion, YourStory & Inc42 (India), SaaStr community posts.
+- Pitch angles that get accepted: real production numbers ("what running 40 AI agents in prod taught us"),
+  cost teardowns, postmortems, architecture deep-dives. Never "5 benefits of AI".
+- Every post: 1 contextual link to a money page + author bio link to homepage.
+
+### 2.2 Digital PR / data-led linkable assets (the 10x play)
+Create one **original-data asset per quarter** on brynex.in, then pitch it:
+- [ ] Q3 idea: "AI Agent Production Survey — what 50 companies actually pay to run agents" (survey clients + community; journalists link to original data).
+- [ ] Q4 idea: "US vs India AI development rate card 2026" (update annually; evergreen citation magnet — this exact comparison is cited constantly with no authoritative source).
+- Pitch via Connectively (ex-HARO), Featured.com, Qwoted, SourceBottle + direct to journalists covering AI outsourcing (TechCrunch, VentureBeat, Economic Times Tech, Mint).
+- [ ] Respond to 3 journalist requests/week (15 min/day). Founder quotes land DR 70–90 links.
+
+### 2.3 Podcast & community circuit (E-E-A-T + branded search)
+- [ ] Founder pitches 2 podcasts/month: AI engineering pods, SaaS growth pods, India startup pods. Show-notes links are real backlinks; the bigger win is branded-search volume (a ranking factor and an AI-training signal).
+- [ ] Answer 2 questions/week on relevant subreddits (r/SaaS, r/artificial, r/ExperiencedDevs), Indie Hackers, and relevant Slack/Discord communities. No link-dropping — name recognition; LLMs train on Reddit.
+- [ ] Quora: claim topic authority on "AI agent development cost", "offshore development India" questions (Quora pages rank AND get cited by AI engines).
+
+### 2.4 Strategic partnerships & ecosystem links
+- [ ] Apply to partner directories of the tools already in the stack: **LangChain partner/experts list, Vercel agency partners, MongoDB partners, AWS Partner Network (Select tier), Pinecone/Qdrant partner pages.** These are DR-80+ followed links that also generate referral leads.
+- [ ] Co-marketing with non-competing agencies (design studios, fractional CTO networks): mutual case studies, not link swaps.
+
+---
+
+## Phase 3 — Scale & GEO/AI-search dominance (Months 3–6, then ongoing)
+
+### 3.1 Generative Engine Optimization (GEO)
+AI answers (Google AI Overviews, ChatGPT, Perplexity, Gemini) now front-run classic rankings;
+AI-referred visitors convert ~5x better. Off-page levers:
+- [ ] Get listed in "best AI agent development companies" roundup posts — find every article ranking for that query (US + India variants) and pitch inclusion with case-study proof. These roundups are the #1 source LLMs cite for vendor recommendations.
+- [ ] Wikipedia-adjacent presence: Wikidata entity for Brynex Labs (needs 2–3 independent press mentions first — Phase 2 PR feeds this).
+- [ ] Keep Crunchbase, LinkedIn, Clutch descriptions verbatim-consistent (LLMs reconcile entities by string overlap).
+- [ ] Monitor AI citations monthly: ask ChatGPT/Perplexity/Gemini "best AI agent development companies in India / for US startups" and log whether Brynex appears (tracking sheet: `docs/seo/geo-citation-log.md`).
+
+### 3.2 Link reclamation & competitor gap (monthly, 1 hr)
+- [ ] Ahrefs alert for unlinked "Brynex" mentions → request the link.
+- [ ] Quarterly competitor backlink-gap run (vs 3 ranking competitors per pillar from KEYWORD-STRATEGY.md) → replicate their wins (directories, guest posts, roundups they're in and we're not).
+- [ ] Broken-link building in AI/SaaS engineering content (find 404'd resources ranking pages link to; offer our guide as the replacement).
+
+### 3.3 India-specific local authority
+- [ ] NASSCOM membership (directory link + credibility badge that closes Indian enterprise deals).
+- [ ] India press: YourStory, Inc42, Analytics India Magazine company profiles & founder bylines.
+- [ ] Local citations: JustDial, Sulekha, IndiaMART (B2B searchers actually use these), TiE chapter membership.
+- [ ] Startup-ecosystem listings: Startup India registration (DPIIT) → .gov.in backlink.
+
+### 3.4 Open source as link infrastructure (engineer-led, 1 repo/quarter)
+- [ ] Release small, genuinely useful OSS: e.g. a LangGraph agent-eval starter, an MCP server, a Next.js SEO schema helper. README links to brynex.in.
+- [ ] Submit to awesome-lists (awesome-langchain, awesome-llm, awesome-nextjs) — followed links from DR-80+ GitHub repos, plus direct developer-buyer visibility.
+- [ ] Write the launch post on the blog + dev.to (each repo = content + links + leads).
+
+---
+
+## What NOT to do (penalty & waste avoidance)
+
+- ❌ Fiverr/marketplace "high DA backlink" packages — guaranteed-toxic.
+- ❌ Mass directory submission tools (200 directories = 195 spam signals).
+- ❌ Reciprocal link-exchange schemes and "link farms" disguised as guest-post networks.
+- ❌ Exact-match anchor text everywhere — keep anchors natural (brand name ~60%, URL ~20%, keyword ~20%).
+- ❌ City landing pages for cities with no real presence.
+- ❌ AI-generated guest posts submitted at scale — publishers detect it; reputation damage outlasts any link.
+
+---
+
+## KPIs & operating rhythm
+
+| Metric | Tool | Baseline (set now) | 6-month target |
+|---|---|---|---|
+| Referring domains | Ahrefs/Semrush | TBD | +60–80 quality RDs |
+| DR / Authority Score | Ahrefs | TBD | +10–15 |
+| BOFU keywords in top 10 (US) | GSC/rank tracker | 0–2 | 6–8 |
+| BOFU keywords in top 10 (IN) | GSC/rank tracker | 0–2 | 10+ |
+| Branded searches/month | GSC | TBD | 3x |
+| Clutch reviews | Clutch | 0 | 8+ |
+| AI-engine citations (monthly check) | manual log | 0 | cited in 2+ engines for 3+ queries |
+| Organic → lead conversions/month | GA4 + leads DB | TBD | 15–25 |
+
+**Weekly (2–3 hrs):** 3 journalist-request responses, 2 community answers, 1 outreach batch (5 emails).
+**Monthly:** 2 guest posts/bylines, 1 podcast pitch round, link-reclamation pass, GEO citation log.
+**Quarterly:** 1 data asset, 1 OSS release, competitor gap analysis, this doc reviewed & updated.
+
+---
+
+## Immediate next 7 days (do these first)
+
+1. Create Clutch + GoodFirms + Google Business Profile (≈3 hrs total) and request first 3 client reviews.
+2. Set Ahrefs/Semrush baseline numbers into the KPI table above.
+3. Align LinkedIn/X/Crunchbase descriptions with the new on-page positioning ("AI Agent Development & Custom Software Company").
+4. Apply to LangChain experts & Vercel partners directories.
+5. Sign up for Connectively/Featured/Qwoted and answer the first journalist request.

--- a/src/app/(site)/about/page.tsx
+++ b/src/app/(site)/about/page.tsx
@@ -3,12 +3,12 @@ import SectionWrapper from '@/components/SectionWrapper';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
-    title: 'About Brynex Labs | Precision Engineering & Product Strategy',
-    description: 'Learn about Brynex Labs, our mission to bridge technical complexity with business outcomes, and the founder story behind our senior-led engineering collective.',
+    title: 'About Brynex Labs | AI & Software Development Company in India',
+    description: 'Brynex Labs is a senior-led AI and software development company based in India, serving startups and enterprises in the USA and worldwide. Meet the team and the mission behind our engineering collective.',
     alternates: { canonical: '/about' },
     openGraph: {
-        title: 'About Brynex Labs | Precision Engineering & Product Strategy',
-        description: 'Learn about Brynex Labs, our mission to bridge technical complexity with business outcomes, and the founder story behind our senior-led engineering collective.',
+        title: 'About Brynex Labs | AI & Software Development Company in India',
+        description: 'A senior-led AI and software development company based in India, serving startups and enterprises in the USA and worldwide.',
         url: '/about'
     }
 };
@@ -53,7 +53,7 @@ const values = [
 ];
 
 const stats = [
-    { label: 'Avg. Experience', value: '7+ Years' },
+    { label: 'Avg. Experience', value: '4+ Years' },
     { label: 'Project Success', value: '100%' },
     { label: 'Senior Engineers', value: '10+' },
     { label: 'Global Clients', value: '25+' },

--- a/src/app/(site)/ai-development-company-in-india/page.tsx
+++ b/src/app/(site)/ai-development-company-in-india/page.tsx
@@ -1,0 +1,161 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import SectionWrapper from '@/components/SectionWrapper';
+
+export const metadata: Metadata = {
+    title: 'AI Development Company in India | Brynex Labs',
+    description: 'Brynex Labs is a top AI development company in India building AI agents, LLM applications, RAG systems & custom software for clients in the USA, UK, Australia & India. Get a free consultation.',
+    alternates: { canonical: '/ai-development-company-in-india' },
+    openGraph: {
+        title: 'AI Development Company in India | Brynex Labs',
+        description: 'Top AI development company in India — AI agents, LLM applications, RAG systems & custom software for clients in the USA, UK, Australia & India.',
+        url: '/ai-development-company-in-india',
+        type: 'website',
+    },
+};
+
+const offerings = [
+    { title: 'AI Agent Development', href: '/services/ai-agents-automation', description: 'Autonomous, tool-using AI agents built on LangChain, LangGraph, and CrewAI that automate support, operations, and data workflows end-to-end.' },
+    { title: 'RAG & LLM Applications', href: '/services/ai-agents-automation', description: 'Retrieval-Augmented Generation over your documents, tickets, and databases using Pinecone, Qdrant, and pgvector — accurate, grounded AI on your own data.' },
+    { title: 'Custom Software & SaaS Development', href: '/services/ai-native-software-engineering', description: 'Full-cycle product engineering: multi-tenant SaaS platforms, web & mobile apps, and cloud infrastructure — built AI-first with Next.js, Python, and AWS/GCP.' },
+    { title: 'SaaS SEO & Organic Growth', href: '/services/saas-seo', description: 'Revenue-focused SEO for B2B SaaS companies — BOFU keywords, programmatic SEO, and CRO that turn organic traffic into demos and pipeline.' },
+];
+
+const reasons = [
+    { title: '40–60% Lower Cost, Same Quality', description: 'Senior AI engineers in India deliver at $25–$45/hour versus $120–$250/hour in the US — with identical tooling, code review standards, and production rigor.' },
+    { title: 'Senior-Led Engineering Collective', description: '10+ senior engineers with 4+ years average experience. No juniors learning on your budget, no bloated management layers between you and your team.' },
+    { title: 'US & Global Timezone Coverage', description: 'Guaranteed overlap with US Eastern and Pacific hours, async-first daily updates, and US-style contracts with NDA and full IP transfer.' },
+    { title: 'Production AI, Not Demos', description: 'Evaluation suites, guardrails, observability, and cost optimization are part of every AI build — so what we ship keeps working after launch.' },
+];
+
+const faqs = [
+    { q: 'Why hire an AI development company in India?', a: 'India hosts nearly 60% of global IT outsourcing with a 5.9-million-strong tech workforce. Companies in the USA and Europe typically save 40–60% on engineering costs while accessing senior AI talent experienced with LangChain, RAG, and production LLM systems.' },
+    { q: 'How much does AI development cost in India?', a: 'With Brynex Labs, a focused AI agent pilot starts at $4,999, production agent systems at $12,999, and a production-ready MVP at $9,999. Dedicated senior AI engineers start near $3,000/month — roughly half of comparable US rates.' },
+    { q: 'Do you work with clients in the USA, UK, and Australia?', a: 'Yes — most of our clients are international. We provide guaranteed timezone overlap, USD invoicing, US-style contracts with NDA, and full intellectual property transfer on every engagement.' },
+    { q: 'Which AI technologies do you specialize in?', a: 'LangChain, LangGraph, CrewAI, and LlamaIndex for orchestration; OpenAI GPT, Anthropic Claude, and Gemini plus self-hosted open-source models; Pinecone, Qdrant, and pgvector for RAG; LangSmith for evaluation and observability.' },
+    { q: 'How do we start a project with Brynex Labs?', a: 'Book a free consultation. Within 48–72 hours we run a discovery call, map your use case and ROI, and send a fixed-scope proposal — you only commit once the scope and price are clear.' },
+];
+
+const jsonLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+        {
+            "@type": ["Organization", "ProfessionalService"],
+            "name": "Brynex Labs",
+            "@id": "https://brynex.in/#organization",
+            "description": "AI development company in India building AI agents, LLM applications, RAG systems, and custom software for clients in the USA, UK, Australia, and India.",
+            "url": "https://brynex.in",
+            "email": "hello@brynex.in",
+            "address": { "@type": "PostalAddress", "addressCountry": "IN" },
+            "areaServed": [
+                { "@type": "Country", "name": "United States" },
+                { "@type": "Country", "name": "India" },
+                { "@type": "Country", "name": "United Kingdom" },
+                { "@type": "Country", "name": "Australia" }
+            ]
+        },
+        {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+                { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://brynex.in" },
+                { "@type": "ListItem", "position": 2, "name": "AI Development Company in India", "item": "https://brynex.in/ai-development-company-in-india" }
+            ]
+        },
+        {
+            "@type": "FAQPage",
+            "mainEntity": faqs.map((faq) => ({
+                "@type": "Question",
+                "name": faq.q,
+                "acceptedAnswer": { "@type": "Answer", "text": faq.a }
+            }))
+        }
+    ]
+};
+
+export default function AIDevelopmentCompanyIndiaPage() {
+    return (
+        <div className="pt-32 pb-16">
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+            />
+            <SectionWrapper>
+                {/* Hero */}
+                <div className="max-w-3xl mb-20">
+                    <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-foreground mb-6 tracking-tight">
+                        AI Development Company in <span className="text-accent">India</span>, Trusted Globally
+                    </h1>
+                    <p className="text-xl text-foreground-secondary leading-relaxed mb-8">
+                        Brynex Labs builds production-grade AI agents, LLM applications, and custom software from India for startups and enterprises in the USA, UK, Australia, and India — senior engineers, fixed-scope pricing, and full IP ownership.
+                    </p>
+                    <div className="flex flex-wrap gap-4">
+                        <Link href="/contact" className="inline-flex items-center px-8 py-4 rounded-full bg-accent text-white font-bold hover:opacity-90 transition-opacity">
+                            Get a Free Consultation
+                        </Link>
+                        <Link href="/case-studies" className="inline-flex items-center px-8 py-4 rounded-full border border-border text-foreground font-bold hover:border-accent transition-colors">
+                            See Our Results
+                        </Link>
+                    </div>
+                </div>
+
+                {/* What we build */}
+                <div className="mb-20">
+                    <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-10 tracking-tight">
+                        AI &amp; Software Services We <span className="text-accent">Deliver</span>
+                    </h2>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        {offerings.map((offering) => (
+                            <Link key={offering.title} href={offering.href} className="group p-8 bg-background-secondary border border-border rounded-2xl hover:border-accent/40 transition-colors block">
+                                <h3 className="font-bold text-xl text-foreground mb-3 group-hover:text-accent transition-colors">{offering.title}</h3>
+                                <p className="text-foreground-secondary text-sm leading-relaxed">{offering.description}</p>
+                            </Link>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Why India / Why Brynex */}
+                <div className="mb-20">
+                    <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-10 tracking-tight">
+                        Why Global Companies Choose <span className="text-accent">Brynex Labs</span>
+                    </h2>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+                        {reasons.map((reason) => (
+                            <div key={reason.title} className="p-8 bg-background-card border border-border rounded-2xl">
+                                <h3 className="font-bold text-xl text-foreground mb-3">{reason.title}</h3>
+                                <p className="text-foreground-secondary text-sm leading-relaxed">{reason.description}</p>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* FAQs */}
+                <div className="mb-20 max-w-3xl">
+                    <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-10 tracking-tight">
+                        Frequently Asked <span className="text-accent">Questions</span>
+                    </h2>
+                    <div className="space-y-6">
+                        {faqs.map((faq) => (
+                            <div key={faq.q} className="p-6 bg-background-secondary border border-border rounded-xl">
+                                <h3 className="font-bold text-lg text-foreground mb-2">{faq.q}</h3>
+                                <p className="text-foreground-secondary text-sm leading-relaxed">{faq.a}</p>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Final CTA */}
+                <div className="text-center py-12 px-6 bg-background-card border border-border rounded-[2rem]">
+                    <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4 tracking-tight">
+                        Build your AI product with India&apos;s senior engineers
+                    </h2>
+                    <p className="text-foreground-secondary text-lg max-w-2xl mx-auto mb-8">
+                        Free discovery call, fixed-scope proposal within 72 hours, and a team that ships to production — not just prototypes.
+                    </p>
+                    <Link href="/contact" className="inline-flex items-center px-8 py-4 rounded-full bg-accent text-white font-bold hover:opacity-90 transition-opacity">
+                        Start Your Project
+                    </Link>
+                </div>
+            </SectionWrapper>
+        </div>
+    );
+}

--- a/src/app/(site)/blog/page.tsx
+++ b/src/app/(site)/blog/page.tsx
@@ -8,12 +8,12 @@ import { Metadata } from 'next';
 export const revalidate = 300;
 
 export const metadata: Metadata = {
-    title: 'Insights & Engineering Blog | Brynex Labs',
-    description: 'Deep dives on SaaS Architecture, Autonomous AI Agents, and scalable Cloud engineering from the Brynex Labs collective.',
+    title: 'AI, SaaS & Software Engineering Blog | Brynex Labs',
+    description: 'Practical guides on AI agent development, SaaS architecture, cloud engineering, and SaaS SEO — written by the senior engineers at Brynex Labs.',
     alternates: { canonical: '/blog' },
     openGraph: {
-        title: 'Insights & Engineering Blog | Brynex Labs',
-        description: 'Deep dives on SaaS Architecture, Autonomous AI Agents, and scalable Cloud engineering from the Brynex Labs collective.',
+        title: 'AI, SaaS & Software Engineering Blog | Brynex Labs',
+        description: 'Practical guides on AI agent development, SaaS architecture, cloud engineering, and SaaS SEO — written by the senior engineers at Brynex Labs.',
         url: '/blog',
         type: 'website',
     },

--- a/src/app/(site)/case-studies/page.tsx
+++ b/src/app/(site)/case-studies/page.tsx
@@ -4,12 +4,12 @@ import { caseStudies } from '@/data/case-studies';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
-    title: 'Success Stories & Case Studies | Brynex Labs',
-    description: 'Explore how Brynex Labs helps startups and enterprises ship production-grade software through real-world examples of our work.',
+    title: 'Software & AI Development Case Studies | Brynex Labs',
+    description: 'Real results from AI agent, SaaS, and custom software development projects — see how Brynex Labs helps startups and enterprises in the USA & India ship production-grade software.',
     alternates: { canonical: '/case-studies' },
     openGraph: {
-        title: 'Success Stories & Case Studies | Brynex Labs',
-        description: 'Explore how Brynex Labs helps startups and enterprises ship production-grade software through real-world examples of our work.',
+        title: 'Software & AI Development Case Studies | Brynex Labs',
+        description: 'Real results from AI agent, SaaS, and custom software development projects for startups and enterprises.',
         url: '/case-studies'
     }
 };

--- a/src/app/(site)/contact/page.tsx
+++ b/src/app/(site)/contact/page.tsx
@@ -3,12 +3,12 @@ import SectionWrapper from '@/components/SectionWrapper';
 import ContactForm from '@/components/ContactForm';
 
 export const metadata: Metadata = {
-    title: 'Consult with Our Engineering Experts | Brynex Labs',
-    description: 'Ready to build production-grade software? Contact Brynex Labs to discuss your AI, SaaS, or enterprise product vision. We respond within 6 business hours.',
+    title: 'Contact Brynex Labs | Hire AI & Software Development Experts',
+    description: 'Get a free consultation for AI agent development, custom software, or SaaS SEO. Brynex Labs serves clients in the USA, India & worldwide — we respond within 6 business hours.',
     alternates: { canonical: '/contact' },
     openGraph: {
-        title: 'Consult with Our Engineering Experts | Brynex Labs',
-        description: 'Ready to build production-grade software? Contact Brynex Labs to discuss your AI, SaaS, or enterprise product vision. We respond within 6 business hours.',
+        title: 'Contact Brynex Labs | Hire AI & Software Development Experts',
+        description: 'Get a free consultation for AI agent development, custom software, or SaaS SEO. We respond within 6 business hours.',
         url: '/contact'
     }
 };

--- a/src/app/(site)/hire-ai-developers/page.tsx
+++ b/src/app/(site)/hire-ai-developers/page.tsx
@@ -1,0 +1,180 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import SectionWrapper from '@/components/SectionWrapper';
+
+export const metadata: Metadata = {
+    title: 'Hire AI Developers | Dedicated AI Engineers from $25/hr',
+    description: 'Hire senior AI developers skilled in LangChain, LangGraph, RAG, and LLM integration. Dedicated AI engineers for US, UK & global companies at 40–60% below US rates. Start within 72 hours.',
+    alternates: { canonical: '/hire-ai-developers' },
+    openGraph: {
+        title: 'Hire AI Developers | Dedicated AI Engineers from $25/hr',
+        description: 'Hire senior AI developers skilled in LangChain, LangGraph, RAG, and LLM integration — at 40–60% below US rates. Start within 72 hours.',
+        url: '/hire-ai-developers',
+        type: 'website',
+    },
+};
+
+const skills = [
+    { title: 'AI Agent Development', description: 'Autonomous, tool-using agents built with LangChain, LangGraph, and CrewAI that plan, reason, and execute multi-step workflows in production.' },
+    { title: 'RAG & LLM Integration', description: 'Retrieval-Augmented Generation pipelines over your business data using Pinecone, Qdrant, and pgvector — grounded answers, no hallucinated facts.' },
+    { title: 'Custom LLM Applications', description: 'Chat assistants, copilots, document intelligence, and AI-powered features integrated directly into your existing SaaS or enterprise product.' },
+    { title: 'Model Fine-Tuning & Self-Hosting', description: 'Fine-tuned and self-hosted open-source models (Llama, Mistral) with vLLM and Ollama for privacy-sensitive and cost-sensitive workloads.' },
+    { title: 'AI Evaluation & Guardrails', description: 'Eval suites, output validation, observability with LangSmith, and guardrails that keep agents accurate, safe, and on-brand.' },
+    { title: 'Full-Stack Product Engineering', description: 'Our AI developers are product engineers first — Python, FastAPI, Next.js, and cloud infrastructure, so AI features ship as part of real software.' },
+];
+
+const engagementModels = [
+    { title: 'Dedicated AI Developer', description: 'A senior AI engineer working exclusively on your product, integrated into your team, tools, and standups — delivered under our existing AI engineering services.', detail: 'From $3,000/month' },
+    { title: 'Dedicated AI Team', description: 'A cross-functional pod — AI engineer, full-stack developer, and tech lead — for end-to-end delivery of our agentic AI and software engineering services.', detail: 'Custom quote' },
+    { title: 'Fixed-Scope AI Project', description: 'A clearly scoped agent, RAG pipeline, or AI feature delivered at a fixed price with milestones through our Agentic AI & Intelligent Automation service.', detail: 'From $4,999' },
+];
+
+const faqs = [
+    { q: 'How quickly can we onboard an AI developer?', a: 'Typically within 48–72 hours of signing. We share matched profiles first, you interview them, and the engineer you select starts immediately — no bait-and-switch.' },
+    { q: 'How much does it cost to hire AI developers from India?', a: 'Senior AI developers through Brynex Labs start around $25–$45/hour (roughly $3,000–$8,000/month for a dedicated engineer) — 40–60% below comparable US rates of $120–$250/hour, with the same tooling and code-quality standards.' },
+    { q: 'Do your AI developers overlap with US working hours?', a: 'Yes. Every engagement includes 3–5 hours of guaranteed overlap with US Eastern or Pacific time, async-first daily updates, and a single senior point of contact.' },
+    { q: 'Who owns the code and IP?', a: 'You do — 100%. Every engagement includes an NDA and full intellectual property transfer in the contract, with code delivered into your own repositories from day one.' },
+    { q: 'What if the developer is not a good fit?', a: 'We offer a risk-free replacement: if an engineer is not working out in the first two weeks, we replace them at no cost or you can exit the engagement.' },
+];
+
+const jsonLd = {
+    "@context": "https://schema.org",
+    "@graph": [
+        {
+            "@type": "Service",
+            "name": "Hire AI Developers",
+            "serviceType": "Dedicated-engineer engagement for Agentic AI & Intelligent Automation and AI-Native Software Engineering",
+            "description": "Hire the senior AI engineers behind Brynex Labs' agentic AI and AI-native software engineering services — skilled in LangChain, LangGraph, RAG, and LLM integration. Serving the USA, UK, Australia, and India.",
+            "provider": {
+                "@type": "Organization",
+                "@id": "https://brynex.in/#organization",
+                "name": "Brynex Labs",
+                "url": "https://brynex.in"
+            },
+            "areaServed": [
+                { "@type": "Country", "name": "United States" },
+                { "@type": "Country", "name": "India" },
+                { "@type": "Country", "name": "United Kingdom" },
+                { "@type": "Country", "name": "Australia" }
+            ],
+            "url": "https://brynex.in/hire-ai-developers"
+        },
+        {
+            "@type": "BreadcrumbList",
+            "itemListElement": [
+                { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://brynex.in" },
+                { "@type": "ListItem", "position": 2, "name": "Hire AI Developers", "item": "https://brynex.in/hire-ai-developers" }
+            ]
+        },
+        {
+            "@type": "FAQPage",
+            "mainEntity": faqs.map((faq) => ({
+                "@type": "Question",
+                "name": faq.q,
+                "acceptedAnswer": { "@type": "Answer", "text": faq.a }
+            }))
+        }
+    ]
+};
+
+export default function HireAIDevelopersPage() {
+    return (
+        <div className="pt-32 pb-16">
+            <script
+                type="application/ld+json"
+                dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+            />
+            <SectionWrapper>
+                {/* Hero */}
+                <div className="max-w-3xl mb-20">
+                    <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-foreground mb-6 tracking-tight">
+                        Hire AI Developers Who Ship to <span className="text-accent">Production</span>
+                    </h1>
+                    <p className="text-xl text-foreground-secondary leading-relaxed mb-8">
+                        Hire the same senior engineers behind our <Link href="/services/ai-agents-automation" className="text-accent hover:underline">Agentic AI &amp; Intelligent Automation</Link> and <Link href="/services/ai-native-software-engineering" className="text-accent hover:underline">AI-Native Software Engineering</Link> services — as a dedicated developer or a full team. Start within 72 hours at 40–60% below US agency rates, with full IP ownership and US-timezone overlap.
+                    </p>
+                    <div className="flex flex-wrap gap-4">
+                        <Link href="/contact" className="inline-flex items-center px-8 py-4 rounded-full bg-accent text-white font-bold hover:opacity-90 transition-opacity">
+                            Get Matched with AI Developers
+                        </Link>
+                        <Link href="/services/ai-agents-automation" className="inline-flex items-center px-8 py-4 rounded-full border border-border text-foreground font-bold hover:border-accent transition-colors">
+                            Explore AI Agent Development
+                        </Link>
+                    </div>
+                </div>
+
+                {/* Skills */}
+                <div className="mb-20">
+                    <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-10 tracking-tight">
+                        What Our AI Developers <span className="text-accent">Do Best</span>
+                    </h2>
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                        {skills.map((skill) => (
+                            <div key={skill.title} className="p-6 bg-background-secondary border border-border rounded-xl hover:border-accent/40 transition-colors">
+                                <h3 className="font-bold text-lg text-foreground mb-3">{skill.title}</h3>
+                                <p className="text-foreground-secondary text-sm leading-relaxed">{skill.description}</p>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Engagement models */}
+                <div className="mb-20">
+                    <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-10 tracking-tight">
+                        Flexible Ways to <span className="text-accent">Engage</span>
+                    </h2>
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
+                        {engagementModels.map((model) => (
+                            <div key={model.title} className="p-8 bg-background-card border border-border rounded-2xl flex flex-col">
+                                <h3 className="font-bold text-xl text-foreground mb-3">{model.title}</h3>
+                                <p className="text-foreground-secondary text-sm leading-relaxed mb-6 flex-1">{model.description}</p>
+                                <span className="text-accent font-bold">{model.detail}</span>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Why Brynex */}
+                <div className="mb-20 max-w-3xl">
+                    <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-6 tracking-tight">
+                        Why Companies in the USA &amp; Europe Hire Through <span className="text-accent">Brynex Labs</span>
+                    </h2>
+                    <ul className="space-y-4 text-foreground-secondary leading-relaxed list-disc pl-5">
+                        <li><strong className="text-foreground">Senior engineers only</strong> — 4+ years average experience; the people you interview are the people who write your code.</li>
+                        <li><strong className="text-foreground">Production AI experience</strong> — our developers have shipped real agents, RAG systems, and LLM features, not just demos. See our <Link href="/case-studies" className="text-accent hover:underline">case studies</Link>.</li>
+                        <li><strong className="text-foreground">40–60% cost advantage</strong> — India-based delivery with US-grade engineering standards, contracts, and communication.</li>
+                        <li><strong className="text-foreground">Zero middlemen</strong> — direct access to your engineers with a senior point of contact, following our <Link href="/how-we-work" className="text-accent hover:underline">transparent delivery process</Link>.</li>
+                    </ul>
+                </div>
+
+                {/* FAQs */}
+                <div className="mb-20 max-w-3xl">
+                    <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-10 tracking-tight">
+                        Hiring AI Developers: <span className="text-accent">FAQs</span>
+                    </h2>
+                    <div className="space-y-6">
+                        {faqs.map((faq) => (
+                            <div key={faq.q} className="p-6 bg-background-secondary border border-border rounded-xl">
+                                <h3 className="font-bold text-lg text-foreground mb-2">{faq.q}</h3>
+                                <p className="text-foreground-secondary text-sm leading-relaxed">{faq.a}</p>
+                            </div>
+                        ))}
+                    </div>
+                </div>
+
+                {/* Final CTA */}
+                <div className="text-center py-12 px-6 bg-background-card border border-border rounded-[2rem]">
+                    <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4 tracking-tight">
+                        Ready to hire your AI developer?
+                    </h2>
+                    <p className="text-foreground-secondary text-lg max-w-2xl mx-auto mb-8">
+                        Tell us what you&apos;re building and we&apos;ll share matched senior profiles within 48 hours — no commitment required.
+                    </p>
+                    <Link href="/contact" className="inline-flex items-center px-8 py-4 rounded-full bg-accent text-white font-bold hover:opacity-90 transition-opacity">
+                        Book a Free Consultation
+                    </Link>
+                </div>
+            </SectionWrapper>
+        </div>
+    );
+}

--- a/src/app/(site)/how-we-work/page.tsx
+++ b/src/app/(site)/how-we-work/page.tsx
@@ -4,12 +4,12 @@ import Engagement from '@/components/sections/Engagement';
 import Link from 'next/link';
 
 export const metadata: Metadata = {
-    title: 'How We Work | Our 6-Phase Engineering Methodology',
-    description: 'Explore the Brynex Labs delivery process. From discovery and architecture to deployment and scaling, see how we build high-performance software.',
+    title: 'How We Work | Agile Software Development Process | Brynex Labs',
+    description: 'Our 6-phase agile software development process — from discovery and architecture to deployment and scaling. See how Brynex Labs delivers production-grade AI and SaaS products.',
     alternates: { canonical: '/how-we-work' },
     openGraph: {
-        title: 'How We Work | Our 6-Phase Engineering Methodology',
-        description: 'Explore the Brynex Labs delivery process. From discovery and architecture to deployment and scaling, see how we build high-performance software.',
+        title: 'How We Work | Agile Software Development Process | Brynex Labs',
+        description: 'Our 6-phase agile software development process — from discovery and architecture to deployment and scaling.',
         url: '/how-we-work'
     }
 };

--- a/src/app/(site)/in/services/[slug]/page.tsx
+++ b/src/app/(site)/in/services/[slug]/page.tsx
@@ -2,7 +2,6 @@ import { Metadata } from 'next';
 import { notFound } from 'next/navigation';
 import { services } from '@/data/services';
 import ServicePageClient from '@/components/ServicePageClient';
-import SaaSSEOClient from '@/components/SaaSSEOClient';
 
 interface PageProps {
     params: {
@@ -10,8 +9,10 @@ interface PageProps {
     };
 }
 
+const indiaServices = () => services.filter((s) => s.marketIN);
+
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
-    const service = services.find((s) => s.slug === params.slug);
+    const service = indiaServices().find((s) => s.slug === params.slug);
 
     if (!service) {
         return {
@@ -19,40 +20,60 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
         };
     }
 
+    const seo = service.marketIN?.seo ?? service.seo;
+
     return {
-        title: service.seo.title,
-        description: service.seo.metaDescription,
+        title: seo.title,
+        description: seo.metaDescription,
         alternates: {
-            canonical: `/services/${service.slug}`,
-            // hreflang: Google serves the en-IN version to Indian searchers
-            // and this version everywhere else (visible in GSC).
-            languages: service.marketIN ? {
+            canonical: `/in/services/${service.slug}`,
+            // hreflang pair with the global version (visible in GSC).
+            languages: {
                 'en-IN': `/in/services/${service.slug}`,
                 'en-US': `/services/${service.slug}`,
                 'x-default': `/services/${service.slug}`,
-            } : undefined,
+            },
         },
         openGraph: {
-            title: service.seo.title,
-            description: service.seo.metaDescription,
-            url: `/services/${service.slug}`,
+            title: seo.title,
+            description: seo.metaDescription,
+            url: `/in/services/${service.slug}`,
             type: 'website',
+            locale: 'en_IN',
         },
     };
 }
 
 export async function generateStaticParams() {
-    return services.map((service) => ({
+    return indiaServices().map((service) => ({
         slug: service.slug,
     }));
 }
 
-export default function ServicePage({ params }: PageProps) {
-    const service = services.find((s) => s.slug === params.slug);
+/** "₹1,49,999" -> "149999" for schema.org Offer price. */
+function numericPrice(price: string): string | null {
+    const digits = price.replace(/[^0-9]/g, '');
+    return digits.length > 0 ? digits : null;
+}
+
+export default function IndiaServicePage({ params }: PageProps) {
+    const service = indiaServices().find((s) => s.slug === params.slug);
 
     if (!service) {
         notFound();
     }
+
+    const inV = service.marketIN!;
+    const faqs = inV.faqs ?? service.faqs;
+    const offers = (service.pricing?.tiers ?? [])
+        .filter((t) => t.priceIN && numericPrice(t.priceIN))
+        .map((t) => ({
+            "@type": "Offer",
+            "name": t.name,
+            "price": numericPrice(t.priceIN!),
+            "priceCurrency": "INR",
+            "url": `https://brynex.in/in/services/${service.slug}`,
+        }));
 
     const jsonLd = {
         "@context": "https://schema.org",
@@ -61,32 +82,28 @@ export default function ServicePage({ params }: PageProps) {
                 "@type": "Service",
                 "name": service.title,
                 "serviceType": service.title,
-                "description": service.description,
+                "description": inV.seo?.metaDescription ?? service.description,
                 "provider": {
                     "@type": "Organization",
                     "@id": "https://brynex.in/#organization",
                     "name": "Brynex Labs",
                     "url": "https://brynex.in"
                 },
-                "areaServed": [
-                    { "@type": "Country", "name": "United States" },
-                    { "@type": "Country", "name": "India" },
-                    { "@type": "Country", "name": "United Kingdom" },
-                    { "@type": "Country", "name": "Australia" }
-                ],
-                "url": `https://brynex.in/services/${service.slug}`
+                "areaServed": { "@type": "Country", "name": "India" },
+                "url": `https://brynex.in/in/services/${service.slug}`,
+                ...(offers.length > 0 ? { "offers": offers } : {})
             },
             {
                 "@type": "BreadcrumbList",
                 "itemListElement": [
                     { "@type": "ListItem", "position": 1, "name": "Home", "item": "https://brynex.in" },
                     { "@type": "ListItem", "position": 2, "name": "Services", "item": "https://brynex.in/services" },
-                    { "@type": "ListItem", "position": 3, "name": service.title, "item": `https://brynex.in/services/${service.slug}` }
+                    { "@type": "ListItem", "position": 3, "name": `${service.title} (India)`, "item": `https://brynex.in/in/services/${service.slug}` }
                 ]
             },
-            ...(service.faqs.length > 0 ? [{
+            ...(faqs.length > 0 ? [{
                 "@type": "FAQPage",
-                "mainEntity": service.faqs.map((faq) => ({
+                "mainEntity": faqs.map((faq) => ({
                     "@type": "Question",
                     "name": faq.question,
                     "acceptedAnswer": { "@type": "Answer", "text": faq.answer }
@@ -101,15 +118,11 @@ export default function ServicePage({ params }: PageProps) {
                 type="application/ld+json"
                 dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
             />
-            {service.slug === 'saas-seo' ? (
-                <SaaSSEOClient service={service} />
-            ) : (
-                <ServicePageClient
-                    service={service}
-                    market="GLOBAL"
-                    alternateUrl={service.marketIN ? `/in/services/${service.slug}` : undefined}
-                />
-            )}
+            <ServicePageClient
+                service={service}
+                market="IN"
+                alternateUrl={`/services/${service.slug}?intl=1`}
+            />
         </>
     );
 }

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -11,31 +11,93 @@ import FinalCTA from '@/components/sections/FinalCTA';
 import { Metadata } from 'next';
 
 export const metadata: Metadata = {
-  title: 'Brynex Labs — Premium Software Development',
-  description: 'Brynex Labs builds reliable websites, business systems, SaaS products and AI-powered software.',
+  title: 'Software Company for AI Agents, Automation & SaaS SEO | Brynex Labs',
+  description: 'Build software that pays for itself. Brynex Labs builds AI agents, intelligent automation, custom software & revenue-driving SaaS SEO — senior engineers trusted by startups and enterprises across the USA & India.',
   alternates: {
     canonical: '/',
   },
   openGraph: {
-    title: 'Brynex Labs — Premium Software Development',
-    description: 'Brynex Labs builds reliable websites, business systems, SaaS products and AI-powered software.',
+    title: 'Software Company for AI Agents, Automation & SaaS SEO | Brynex Labs',
+    description: 'Build software that pays for itself — AI agents, intelligent automation, custom software & SaaS SEO from senior engineers. Serving the USA, India & worldwide.',
     url: '/',
   },
 };
+
+const homeFaqs = [
+  { q: "How fast can you start working on my project?", a: "We typically onboard and kick off new client projects within 48 to 72 hours of signing the agreement, depending on complexity and resource availability." },
+  { q: "Do you integrate AI securely into existing SaaS products?", a: "Absolutely. We specialize in building custom AI agents and integrating strict LLM features securely into existing cloud platforms to automate your specific workflows without exposing private data." },
+  { q: "How do you handle project scope changes?", a: "We work with an agile mindset. If new features are needed, we pivot dynamically, transparently scoping out the differences and adjusting timelines before proceeding." },
+  { q: "Will I own the intellectual property and code?", a: "100%. Upon project completion and final payment, all intellectual property, design assets, and source code are fully transferred and licensed to you." },
+  { q: "Do you provide post-launch support and maintenance?", a: "Yes, we offer flexible post-launch retainers to ensure your application stays updated, secure, and continues to scale smoothly as your user base grows." }
+];
 
 const jsonLd = {
   "@context": "https://schema.org",
   "@graph": [
     {
-      "@type": "Organization",
+      "@type": ["Organization", "ProfessionalService"],
       "@id": "https://brynex.in/#organization",
       "name": "Brynex Labs",
+      "alternateName": "Brynex",
       "url": "https://brynex.in",
       "logo": "https://brynex.in/favicon.ico",
+      "email": "hello@brynex.in",
+      "description": "Software company building production-grade AI agents, intelligent automation, custom software, SaaS platforms, and revenue-focused SaaS SEO for startups and enterprises worldwide.",
+      "areaServed": [
+        { "@type": "Country", "name": "United States" },
+        { "@type": "Country", "name": "India" },
+        { "@type": "Country", "name": "United Kingdom" },
+        { "@type": "Country", "name": "Australia" },
+        { "@type": "Country", "name": "Canada" }
+      ],
+      "address": {
+        "@type": "PostalAddress",
+        "addressCountry": "IN"
+      },
+      "knowsAbout": [
+        "AI agent development",
+        "agentic AI",
+        "LLM application development",
+        "RAG pipelines",
+        "custom software development",
+        "SaaS product engineering",
+        "cloud infrastructure",
+        "SaaS SEO"
+      ],
       "sameAs": [
         "https://x.com/brynexlabs",
         "https://www.linkedin.com/company/brynexlabs"
-      ]
+      ],
+      "hasOfferCatalog": {
+        "@type": "OfferCatalog",
+        "name": "Software & AI Services",
+        "itemListElement": [
+          {
+            "@type": "Offer",
+            "itemOffered": {
+              "@type": "Service",
+              "name": "AI Agent Development & Intelligent Automation",
+              "url": "https://brynex.in/services/ai-agents-automation"
+            }
+          },
+          {
+            "@type": "Offer",
+            "itemOffered": {
+              "@type": "Service",
+              "name": "Custom Software & SaaS Development",
+              "url": "https://brynex.in/services/ai-native-software-engineering"
+            }
+          },
+          {
+            "@type": "Offer",
+            "itemOffered": {
+              "@type": "Service",
+              "name": "SaaS SEO Services for B2B Companies",
+              "url": "https://brynex.in/services/saas-seo"
+            }
+          }
+        ]
+      }
     },
     {
       "@type": "WebSite",
@@ -44,12 +106,16 @@ const jsonLd = {
       "name": "Brynex Labs",
       "publisher": {
         "@id": "https://brynex.in/#organization"
-      },
-      "potentialAction": {
-        "@type": "SearchAction",
-        "target": "https://brynex.in/search?q={search_term_string}",
-        "query-input": "required name=search_term_string"
       }
+    },
+    {
+      "@type": "FAQPage",
+      "@id": "https://brynex.in/#faq",
+      "mainEntity": homeFaqs.map((faq) => ({
+        "@type": "Question",
+        "name": faq.q,
+        "acceptedAnswer": { "@type": "Answer", "text": faq.a }
+      }))
     }
   ]
 };

--- a/src/app/(site)/services/page.tsx
+++ b/src/app/(site)/services/page.tsx
@@ -4,12 +4,12 @@ import ServiceCard from '@/components/ServiceCard';
 import { services } from '@/data/services';
 
 export const metadata: Metadata = {
-    title: 'Expert Software Engineering Services | Brynex Labs',
-    description: 'Explore our services: agentic AI and intelligent automation, AI-native software engineering, and revenue-focused SaaS SEO.',
+    title: 'AI Development, Custom Software & SaaS SEO Services | Brynex Labs',
+    description: 'Explore Brynex Labs services: AI agent development & intelligent automation, custom software & SaaS development, and revenue-focused SaaS SEO — for startups and enterprises in the USA & India.',
     alternates: { canonical: '/services' },
     openGraph: {
-        title: 'Expert Software Engineering Services | Brynex Labs',
-        description: 'Explore our services: agentic AI and intelligent automation, AI-native software engineering, and revenue-focused SaaS SEO.',
+        title: 'AI Development, Custom Software & SaaS SEO Services | Brynex Labs',
+        description: 'AI agent development, custom software & SaaS engineering, and revenue-focused SaaS SEO — for startups and enterprises in the USA & India.',
         url: '/services'
     }
 };

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,13 +12,27 @@ const inter = Inter({
 
 export const metadata: Metadata = {
   metadataBase: new URL('https://brynex.in'),
-  title: 'Brynex Labs — Premium Software Development',
+  title: {
+    default: 'Software Company for AI Agents, Automation & SaaS SEO | Brynex Labs',
+    template: '%s',
+  },
   description:
-    'Brynex Labs builds reliable websites, business systems, SaaS products and AI-powered software — from small improvements to large-scale platforms.',
+    'Build software that pays for itself. Brynex Labs is the software company behind AI agents, intelligent automation, custom software development & revenue-driving SaaS SEO — trusted by startups and enterprises across the USA & India.',
+  applicationName: 'Brynex Labs',
+  keywords: [
+    'AI agent development company',
+    'AI development company',
+    'custom software development company',
+    'SaaS development company',
+    'AI automation agency',
+    'SaaS SEO agency',
+    'software development company India',
+    'hire AI developers',
+  ],
   openGraph: {
-    title: 'Brynex Labs — Premium Software Development',
+    title: 'Software Company for AI Agents, Automation & SaaS SEO | Brynex Labs',
     description:
-      'Premium software development for businesses, startups and product teams. Websites, SaaS, AI solutions and more.',
+      'Build software that pays for itself — AI agents, intelligent automation, custom software & SaaS SEO from senior engineers. Serving the USA, India & worldwide.',
     type: 'website',
     url: 'https://brynex.in',
     locale: 'en_US',
@@ -26,14 +40,23 @@ export const metadata: Metadata = {
   },
   twitter: {
     card: 'summary_large_image',
-    title: 'Brynex Labs — Premium Software Development',
+    site: '@brynexlabs',
+    title: 'Software Company for AI Agents, Automation & SaaS SEO | Brynex Labs',
     description:
-      'Premium software development for businesses, startups and product teams. Websites, SaaS, AI solutions and more.',
+      'Build software that pays for itself — AI agents, intelligent automation, custom software & SaaS SEO from senior engineers. Serving the USA, India & worldwide.',
   },
   robots: {
     index: true,
     follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
   },
+  category: 'technology',
   verification: process.env.NEXT_PUBLIC_GSC_VERIFICATION ? {
     google: process.env.NEXT_PUBLIC_GSC_VERIFICATION,
   } : undefined,

--- a/src/app/llms.txt/route.ts
+++ b/src/app/llms.txt/route.ts
@@ -1,0 +1,39 @@
+export const dynamic = 'force-static';
+
+const LLMS_TXT = `# Brynex Labs
+
+> Brynex Labs (https://brynex.in) is a software company building production-grade AI agents, intelligent automation, custom software & SaaS platforms, and revenue-focused SaaS SEO — for startups and enterprises in the USA, India, UK, and Australia. Senior engineers (4+ years average experience), fixed-scope pricing, 100% code & IP ownership.
+
+## Services
+
+- [Agentic AI & Intelligent Automation](https://brynex.in/services/ai-agents-automation): Autonomous AI agents built with LangChain, LangGraph, CrewAI, and RAG over business data. Pilots from $4,999; production agent systems from $12,999.
+- [AI-Native Software Engineering](https://brynex.in/services/ai-native-software-engineering): Custom software, multi-tenant SaaS platforms, web & mobile apps, cloud & DevOps, legacy modernization. MVPs from $9,999; SaaS platforms from $24,999.
+- [SaaS SEO for B2B Companies](https://brynex.in/services/saas-seo): Revenue-focused SEO — BOFU keywords, programmatic SEO, and CRO that turn organic traffic into demos and pipeline.
+
+## India
+
+- [AI Agent Development in India](https://brynex.in/in/services/ai-agents-automation): Indian-market pricing — pilots from ₹49,999, production systems from ₹1,49,999. GST invoicing.
+- [Custom Software Development in India](https://brynex.in/in/services/ai-native-software-engineering): MVPs from ₹99,999, SaaS platforms from ₹2,49,999. GST invoicing.
+- [AI Development Company in India](https://brynex.in/ai-development-company-in-india): Overview of services for the Indian market and offshore clients.
+
+## Hiring & Engagement
+
+- [Hire AI Developers](https://brynex.in/hire-ai-developers): Dedicated senior AI engineers from $3,000/month — 40–60% below US agency rates, US-timezone overlap, NDA & full IP transfer.
+- [How We Work](https://brynex.in/how-we-work): 6-phase agile delivery process with weekly demos.
+- [Contact](https://brynex.in/contact): Free consultation; response within 6 business hours. Email: hello@brynex.in
+
+## Resources
+
+- [Case Studies](https://brynex.in/case-studies): Real project outcomes, including 1M+ MAU SaaS scaling and healthcare data platforms.
+- [Blog](https://brynex.in/blog): Guides on AI agents, RAG, SaaS architecture, cloud engineering, and SaaS SEO.
+- [About](https://brynex.in/about): Senior-led engineering collective based in India, working globally.
+`;
+
+export function GET() {
+    return new Response(LLMS_TXT, {
+        headers: {
+            'content-type': 'text/plain; charset=utf-8',
+            'cache-control': 'public, max-age=3600',
+        },
+    });
+}

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,7 +1,7 @@
 import { ImageResponse } from 'next/og';
 
 export const runtime = 'edge';
-export const alt = 'Brynex Labs — Premium Software Development';
+export const alt = 'Brynex Labs — AI Agent Development & Custom Software Company';
 export const size = { width: 1200, height: 630 };
 export const contentType = 'image/png';
 
@@ -38,7 +38,7 @@ export default function OpenGraphImage() {
                     </div>
                     <span style={{ fontSize: 28, fontWeight: 700, color: '#c2410c', letterSpacing: 18, marginTop: 4 }}>LABS</span>
                     <span style={{ fontSize: 30, color: '#a3a3a3', marginTop: 48 }}>
-                        AI-Native Software Engineering · Agentic AI · SaaS SEO
+                        AI Agent Development · Custom Software · SaaS SEO
                     </span>
                 </div>
                 <div

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,12 +1,44 @@
 import type { MetadataRoute } from 'next';
 
+const PRIVATE_PATHS = ['/api/', '/admin/', '/super-admin/', '/private/'];
+
+// AI search & answer-engine crawlers, explicitly welcomed so the site gets
+// cited in ChatGPT, Claude, Perplexity, Gemini, Copilot, and AI Overviews.
+const AI_CRAWLERS = [
+  'GPTBot', // OpenAI training
+  'OAI-SearchBot', // ChatGPT search index
+  'ChatGPT-User', // ChatGPT live browsing
+  'ClaudeBot', // Anthropic crawler
+  'Claude-Web', // Claude live browsing
+  'anthropic-ai',
+  'PerplexityBot', // Perplexity index
+  'Perplexity-User', // Perplexity live browsing
+  'Google-Extended', // Gemini training
+  'GoogleOther',
+  'Bingbot', // Powers Copilot + ChatGPT search
+  'Amazonbot', // Alexa/Rufus
+  'Applebot', // Siri/Apple Intelligence
+  'Applebot-Extended',
+  'DuckAssistBot',
+  'cohere-ai',
+  'meta-externalagent', // Meta AI
+  'CCBot', // Common Crawl (feeds many LLMs)
+];
+
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: {
-      userAgent: '*',
-      allow: '/',
-      disallow: ['/api/', '/admin/', '/super-admin/', '/private/'], // Common private areas, adjust if needed
-    },
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: PRIVATE_PATHS,
+      },
+      ...AI_CRAWLERS.map((userAgent) => ({
+        userAgent,
+        allow: '/',
+        disallow: PRIVATE_PATHS,
+      })),
+    ],
     sitemap: 'https://brynex.in/sitemap.xml',
   };
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from 'next';
 import { services } from '@/data/services';
+import { caseStudies } from '@/data/case-studies';
 import { getAllPosts } from '@/lib/blogService';
 
 // Computed per request so CMS-published articles appear immediately for crawlers.
@@ -29,11 +30,36 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: route === '' ? 1 : 0.8,
   }));
 
+  const landingRoutes = ['/hire-ai-developers', '/ai-development-company-in-india'];
+  const landingMappings = landingRoutes.map((route) => ({
+    url: `${baseUrl}${route}`,
+    lastModified,
+    changeFrequency: 'monthly' as const,
+    priority: 0.9,
+  }));
+
   const serviceMappings = services.map((service) => ({
     url: `${baseUrl}/services/${service.slug}`,
     lastModified,
     changeFrequency: 'monthly' as const,
     priority: 0.9,
+  }));
+
+  // India-market variants (hreflang en-IN pairs of the global service pages).
+  const indiaServiceMappings = services
+    .filter((service) => service.marketIN)
+    .map((service) => ({
+      url: `${baseUrl}/in/services/${service.slug}`,
+      lastModified,
+      changeFrequency: 'monthly' as const,
+      priority: 0.9,
+    }));
+
+  const caseStudyMappings = caseStudies.map((study) => ({
+    url: `${baseUrl}/case-studies/${study.slug}`,
+    lastModified,
+    changeFrequency: 'monthly' as const,
+    priority: 0.7,
   }));
 
   const posts = await getAllPosts();
@@ -44,5 +70,5 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     priority: 0.7,
   }));
 
-  return [...staticMappings, ...serviceMappings, ...blogMappings];
+  return [...staticMappings, ...landingMappings, ...serviceMappings, ...indiaServiceMappings, ...caseStudyMappings, ...blogMappings];
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -66,6 +66,8 @@ export default function Footer() {
                             {[
                                 { label: 'About', href: '/about' },
                                 { label: 'Case Studies', href: '/case-studies' },
+                                { label: 'Hire AI Developers', href: '/hire-ai-developers' },
+                                { label: 'AI Development in India', href: '/ai-development-company-in-india' },
                                 { label: 'Careers', href: '/careers' },
                                 { label: 'Blog', href: '/blog' },
                                 { label: 'Contact', href: '/contact' },

--- a/src/components/ServicePageClient.tsx
+++ b/src/components/ServicePageClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import Link from 'next/link';
 import { ServiceDetail } from '@/data/services';
 import SectionWrapper from './SectionWrapper';
 import Button from './Button';
@@ -10,10 +11,28 @@ import { trackConversion_StartProjectClick, trackConversion_ServiceView } from '
 
 interface ServicePageClientProps {
     service: ServiceDetail;
+    /** Which market variant this (static, crawlable) page renders. */
+    market?: 'GLOBAL' | 'IN';
+    /** URL of the other market's version of this page, rendered as a toggle link. */
+    alternateUrl?: string;
 }
 
-export default function ServicePageClient({ service }: ServicePageClientProps) {
+function SectionBadge({ label }: { label: string }) {
+    return (
+        <div className="inline-flex items-center gap-2 mb-6 px-3 py-1.5 rounded-full border border-border bg-background-secondary/50">
+            <span className="w-1.5 h-1.5 rounded-full bg-accent animate-pulse" aria-hidden="true" />
+            <span className="text-foreground-muted text-xs font-medium uppercase tracking-wider">{label}</span>
+        </div>
+    );
+}
+
+export default function ServicePageClient({ service, market = 'GLOBAL', alternateUrl }: ServicePageClientProps) {
     const [isModalOpen, setIsModalOpen] = useState(false);
+
+    // India-market overrides — resolved at build time per route variant, so
+    // both versions are fully static and independently crawlable.
+    const inV = market === 'IN' ? service.marketIN : undefined;
+    const faqs = (market === 'IN' && service.marketIN?.faqs) ? service.marketIN.faqs : service.faqs;
 
     useEffect(() => {
         if (service?.title) {
@@ -21,35 +40,57 @@ export default function ServicePageClient({ service }: ServicePageClientProps) {
         }
     }, [service?.title]);
 
+    const openModal = (source: string) => {
+        trackConversion_StartProjectClick(`Service CTA - ${service.title} - ${source} [${market}]`);
+        setIsModalOpen(true);
+    };
+
     return (
         <div className="pt-24 pb-16">
             <ContactModal isOpen={isModalOpen} onClose={() => setIsModalOpen(false)} />
 
             {/* Hero Section */}
-            <SectionWrapper className="relative overflow-hidden mb-16">
-                <div className="text-center max-w-4xl mx-auto">
-                    <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-foreground mb-8 tracking-tight">
+            <section className="relative flex items-center justify-center px-6 md:px-8 pt-16 pb-8 overflow-hidden">
+                {/* Background glow */}
+                <div className="absolute inset-0 pointer-events-none" aria-hidden="true">
+                    <div className="absolute top-[0%] left-1/2 -translate-x-1/2 w-[800px] h-[600px] bg-hero-glow animate-glow-pulse" />
+                    <div className="absolute top-[10%] left-1/2 -translate-x-1/2 w-[1200px] h-[800px] bg-[radial-gradient(ellipse_at_center,rgba(194,65,12,0.06)_0%,transparent_60%)]" />
+                    <div
+                        className="absolute inset-0 opacity-[0.03] dark:opacity-[0.03] invert dark:invert-0"
+                        style={{
+                            backgroundImage: `linear-gradient(rgba(0,0,0,0.1) 1px, transparent 1px), linear-gradient(90deg, rgba(0,0,0,0.1) 1px, transparent 1px)`,
+                            backgroundSize: '60px 60px',
+                        }}
+                    />
+                </div>
+
+                <div className="relative z-10 text-center max-w-4xl mx-auto">
+                    {service.badge && <SectionBadge label={service.badge} />}
+                    <h1 className="text-4xl md:text-5xl lg:text-6xl font-bold text-foreground mb-8 tracking-tight leading-[1.1] animate-fade-in-up">
                         {service.title.split(' ').map((word, i) => (
-                            <span key={word} className={i >= service.title.split(' ').length - 2 ? 'text-accent' : ''}>
+                            <span key={`${word}-${i}`} className={i >= service.title.split(' ').length - 2 ? 'text-accent' : ''}>
                                 {word}{' '}
                             </span>
                         ))}
                     </h1>
-                    {service.hook ? (
-                        <div className="max-w-4xl mx-auto">
-                            <h2 className="text-2xl md:text-3xl text-foreground-secondary leading-relaxed font-medium">
-                                {service.hook}
-                            </h2>
-                        </div>
-                    ) : (
-                        <p className="text-xl md:text-2xl text-foreground-secondary leading-relaxed">
-                            {service.description}
-                        </p>
-                    )}
+                    <p className="text-lg md:text-xl text-foreground-secondary leading-relaxed max-w-3xl mx-auto animate-fade-in-up" style={{ animationDelay: '0.15s' }}>
+                        {inV?.hook ?? service.hook ?? service.description}
+                    </p>
+                    <div className="flex flex-col sm:flex-row items-center justify-center gap-4 mt-10 animate-fade-in-up" style={{ animationDelay: '0.3s' }}>
+                        <Button onClick={() => openModal('Hero')} variant="primary" size="lg">
+                            {service.customCta?.buttonText ?? 'Start a project'}
+                            <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" className="ml-2">
+                                <path d="M3 8H13M13 8L9 4M13 8L9 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                            </svg>
+                        </Button>
+                    </div>
                 </div>
+            </section>
 
-                {service.metrics && service.metrics.length > 0 && (
-                    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-4xl mx-auto mt-16 pb-8 border-b border-border/50">
+            {/* Metrics */}
+            {service.metrics && service.metrics.length > 0 && (
+                <SectionWrapper className="!py-0 mb-8">
+                    <div className="grid grid-cols-1 md:grid-cols-3 gap-6 max-w-4xl mx-auto pb-8 border-b border-border/50">
                         {service.metrics.map((metric, i) => (
                             <div key={i} className="text-center group p-6 rounded-2xl hover:bg-background-secondary/30 transition-colors">
                                 <div className="text-4xl md:text-5xl font-extrabold text-foreground mb-3 group-hover:scale-110 transition-transform duration-300 group-hover:text-accent">{metric.value}</div>
@@ -57,73 +98,89 @@ export default function ServicePageClient({ service }: ServicePageClientProps) {
                             </div>
                         ))}
                     </div>
-                )}
+                </SectionWrapper>
+            )}
+
+            {/* The Problem */}
+            <SectionWrapper className="bg-background-secondary/10">
+                <div className="max-w-4xl mx-auto">
+                    <div className="text-center mb-12">
+                        <SectionBadge label="The Problem" />
+                        <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+                            {service.problemHeading ?? 'Challenges You Face'}
+                        </h2>
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-5 mb-10">
+                        {service.challenges.map((challenge, i) => (
+                            <div key={i} className="flex items-start gap-4 p-5 rounded-2xl border border-border bg-background-card hover:border-red-500/30 hover:shadow-card transition-all duration-300 group">
+                                <span className="mt-1 flex-shrink-0 w-7 h-7 rounded-full bg-red-500/10 flex items-center justify-center group-hover:bg-red-500/20 transition-colors">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="text-red-500/70">
+                                        <path d="M18 6L6 18M6 6l12 12" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" />
+                                    </svg>
+                                </span>
+                                <span className="text-foreground-secondary leading-relaxed">{challenge}</span>
+                            </div>
+                        ))}
+                    </div>
+                    {service.problemSummary && (
+                        <div className="text-center p-6 rounded-2xl border border-border bg-background-card">
+                            <p className="text-foreground-secondary text-lg">
+                                <span className="font-semibold text-foreground">Result:</span> {service.problemSummary.replace(/^Result:\s*/i, '')}
+                            </p>
+                        </div>
+                    )}
+                </div>
             </SectionWrapper>
 
-            {/* Problem & Solution */}
-            <SectionWrapper className="bg-background-secondary/10">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-12 md:gap-16">
-                    <div>
-                        <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-6">Challenges You Face</h2>
-                        <ul className="space-y-4">
-                            {service.challenges.map((challenge, i) => (
-                                <li key={i} className="flex items-start gap-3">
-                                    <span className="mt-1 w-1.5 h-1.5 rounded-full bg-red-500/60 shrink-0" />
-                                    <span className="text-foreground-secondary">{challenge}</span>
-                                </li>
-                            ))}
-                        </ul>
+            {/* How We Solve It */}
+            <SectionWrapper>
+                <div className="max-w-4xl mx-auto">
+                    <div className="text-center mb-12">
+                        <SectionBadge label="The Solution" />
+                        <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">How We Solve It</h2>
                     </div>
-                    <div>
-                        <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-6">How We Solve It</h2>
-                        <ul className="space-y-4">
-                            {service.solutions.map((solution, i) => (
-                                <li key={i} className="flex items-start gap-3">
-                                    <span className="mt-1 w-1.5 h-1.5 rounded-full bg-green-500/60 shrink-0" />
-                                    <span className="text-foreground-secondary">{solution}</span>
-                                </li>
-                            ))}
-                        </ul>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+                        {service.solutions.map((solution, i) => (
+                            <div key={i} className="flex items-start gap-4 p-5 rounded-2xl border border-border bg-background-card hover:border-accent/40 hover:shadow-card transition-all duration-300 group">
+                                <span className="mt-1 flex-shrink-0 w-7 h-7 rounded-full bg-accent/10 flex items-center justify-center group-hover:bg-accent/20 transition-colors">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="text-accent">
+                                        <path d="M20 6L9 17l-5-5" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" />
+                                    </svg>
+                                </span>
+                                <span className="text-foreground-secondary leading-relaxed">{solution}</span>
+                            </div>
+                        ))}
                     </div>
                 </div>
             </SectionWrapper>
 
-            {/* Target Audience */}
-            {service.targetAudience && (
-                <SectionWrapper>
+            {/* Sub-Services Grid */}
+            {service.subServices && (
+                <SectionWrapper className="bg-background-secondary/10">
                     <div className="text-center mb-12">
-                        <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-4">Who This Is For</h2>
-                        <p className="text-foreground-secondary">We exclusively partner where we can guarantee massive ROI.</p>
+                        <SectionBadge label="What We Offer" />
+                        <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">{service.subServices.heading}</h2>
+                        {service.subServices.subheading && (
+                            <p className="text-foreground-secondary text-lg max-w-2xl mx-auto">{service.subServices.subheading}</p>
+                        )}
                     </div>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-5xl mx-auto">
-                        <div className="bg-green-500/5 border border-green-500/20 rounded-3xl p-8">
-                            <h3 className="text-xl font-bold text-foreground mb-6 flex items-center gap-3">
-                                <span className="flex items-center justify-center w-8 h-8 rounded-full bg-green-500/20 text-green-500 text-sm">✓</span>
-                                Ideal Fit
-                            </h3>
-                            <ul className="space-y-4">
-                                {service.targetAudience.for.map((item, i) => (
-                                    <li key={i} className="flex items-start gap-3 text-foreground-secondary">
-                                        <span className="text-green-500 mt-0.5">•</span>
-                                        <span>{item}</span>
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
-                        <div className="bg-red-500/5 border border-red-500/20 rounded-3xl p-8">
-                            <h3 className="text-xl font-bold text-foreground mb-6 flex items-center gap-3">
-                                <span className="flex items-center justify-center w-8 h-8 rounded-full bg-red-500/20 text-red-500 text-sm">✕</span>
-                                Not a Fit
-                            </h3>
-                            <ul className="space-y-4">
-                                {service.targetAudience.notFor.map((item, i) => (
-                                    <li key={i} className="flex items-start gap-3 text-foreground-secondary">
-                                        <span className="text-red-500 mt-0.5">•</span>
-                                        <span>{item}</span>
-                                    </li>
-                                ))}
-                            </ul>
-                        </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 max-w-6xl mx-auto">
+                        {service.subServices.items.map((item, i) => (
+                            <div key={i} className="rounded-2xl border border-border bg-background-card p-6 hover:border-accent/40 hover:shadow-card-hover transition-all duration-300 group">
+                                <h3 className="text-lg font-bold text-foreground mb-3 group-hover:text-accent transition-colors">
+                                    {item.title}
+                                </h3>
+                                {item.intro && <p className="text-foreground-secondary text-sm mb-4">{item.intro}</p>}
+                                <ul className="space-y-2.5">
+                                    {item.points.map((point, j) => (
+                                        <li key={j} className="flex items-start gap-2 text-sm text-foreground-secondary">
+                                            <span className="text-accent mt-0.5 flex-shrink-0 font-bold">›</span>
+                                            <span>{point}</span>
+                                        </li>
+                                    ))}
+                                </ul>
+                            </div>
+                        ))}
                     </div>
                 </SectionWrapper>
             )}
@@ -133,23 +190,202 @@ export default function ServicePageClient({ service }: ServicePageClientProps) {
                 <SectionWrapper className="bg-background-secondary/30">
                     <div className="max-w-4xl mx-auto">
                         <div className="text-center mb-16">
-                            <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-4">Our Methodology</h2>
-                            <p className="text-foreground-secondary">A proven, engineered approach to scaling results.</p>
+                            <SectionBadge label="Our Framework" />
+                            <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">
+                                {service.processHeading ?? 'Our Methodology'}
+                            </h2>
+                            <p className="text-foreground-secondary text-lg">A proven, engineered approach to scaling results.</p>
                         </div>
-                        <div className="space-y-12">
+                        <div className="space-y-0">
                             {service.process.map((step, i) => (
-                                <div key={i} className="flex flex-col md:flex-row gap-6 md:gap-12 items-start relative group">
-                                    {/* Timeline line */}
+                                <div key={i} className="flex flex-col md:flex-row gap-6 md:gap-10 items-start relative group py-8 first:pt-0 last:pb-0">
                                     {i !== service.process!.length - 1 && (
-                                        <div className="absolute left-8 md:left-10 top-16 bottom-[-3rem] w-px bg-border group-hover:bg-accent/50 transition-colors hidden md:block" />
+                                        <div className="absolute left-8 md:left-10 top-[5.5rem] bottom-0 w-px bg-gradient-to-b from-border to-transparent group-hover:from-accent/40 transition-colors hidden md:block" />
                                     )}
-                                    <div className="flex-shrink-0 w-16 h-16 md:w-20 md:h-20 rounded-2xl bg-background border border-border flex items-center justify-center text-accent text-2xl font-black shadow-sm group-hover:border-accent transition-colors z-10 relative">
+                                    <div className="flex-shrink-0 w-16 h-16 md:w-20 md:h-20 rounded-2xl bg-background border-2 border-border flex items-center justify-center text-accent text-2xl font-black shadow-sm group-hover:border-accent group-hover:shadow-[0_0_20px_rgba(194,65,12,0.15)] transition-all duration-300 z-10 relative">
                                         0{i + 1}
                                     </div>
-                                    <div className="pt-2 md:pt-4">
-                                        <h3 className="text-xl md:text-2xl font-bold text-foreground mb-3">{step.title}</h3>
+                                    <div className="pt-2 md:pt-4 flex-1">
+                                        <h3 className="text-xl md:text-2xl font-bold text-foreground mb-2 group-hover:text-accent transition-colors">{step.title}</h3>
                                         <p className="text-foreground-secondary leading-relaxed text-lg">{step.description}</p>
                                     </div>
+                                </div>
+                            ))}
+                        </div>
+                        {service.processSummary && (
+                            <div className="text-center mt-14 p-8 rounded-2xl bg-accent/5 border border-accent/20 relative overflow-hidden">
+                                <div className="absolute inset-0 bg-accent-glow opacity-30 pointer-events-none" />
+                                <p className="text-foreground font-semibold text-lg relative z-10">{service.processSummary}</p>
+                            </div>
+                        )}
+                    </div>
+                </SectionWrapper>
+            )}
+
+            {/* Target Audience */}
+            {service.targetAudience && (
+                <SectionWrapper>
+                    <div className="text-center mb-12">
+                        <SectionBadge label="Ideal Client" />
+                        <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">Who This Is For</h2>
+                        <p className="text-foreground-secondary text-lg">We exclusively partner where we can guarantee massive ROI.</p>
+                    </div>
+                    <div className="grid grid-cols-1 md:grid-cols-2 gap-8 max-w-5xl mx-auto">
+                        <div className="bg-green-500/5 border border-green-500/20 rounded-3xl p-8 hover:shadow-[0_8px_30px_rgba(34,197,94,0.08)] transition-shadow duration-300">
+                            <h3 className="text-xl font-bold text-foreground mb-6 flex items-center gap-3">
+                                <span className="flex items-center justify-center w-9 h-9 rounded-full bg-green-500/20 text-green-500">
+                                    <svg width="16" height="16" viewBox="0 0 24 24" fill="none"><path d="M20 6L9 17l-5-5" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" /></svg>
+                                </span>
+                                Ideal Fit
+                            </h3>
+                            <ul className="space-y-4">
+                                {service.targetAudience.for.map((item, i) => (
+                                    <li key={i} className="flex items-start gap-3 text-foreground-secondary">
+                                        <span className="text-green-500 mt-1 flex-shrink-0">•</span>
+                                        <span className="leading-relaxed">{item}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                        <div className="bg-red-500/5 border border-red-500/20 rounded-3xl p-8 hover:shadow-[0_8px_30px_rgba(239,68,68,0.08)] transition-shadow duration-300">
+                            <h3 className="text-xl font-bold text-foreground mb-6 flex items-center gap-3">
+                                <span className="flex items-center justify-center w-9 h-9 rounded-full bg-red-500/20 text-red-500">
+                                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none"><path d="M18 6L6 18M6 6l12 12" stroke="currentColor" strokeWidth="3" strokeLinecap="round" /></svg>
+                                </span>
+                                Not a Fit
+                            </h3>
+                            <ul className="space-y-4">
+                                {service.targetAudience.notFor.map((item, i) => (
+                                    <li key={i} className="flex items-start gap-3 text-foreground-secondary">
+                                        <span className="text-red-500 mt-1 flex-shrink-0">•</span>
+                                        <span className="leading-relaxed">{item}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        </div>
+                    </div>
+                </SectionWrapper>
+            )}
+
+            {/* Pricing */}
+            {service.pricing && (
+                <SectionWrapper>
+                    <div className="max-w-6xl mx-auto">
+                        <div className="text-center mb-12">
+                            <SectionBadge label="Pricing" />
+                            <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">{service.pricing.heading}</h2>
+                            {(inV?.pricingSubheading ?? service.pricing.subheading) && (
+                                <p className="text-foreground-secondary text-lg max-w-2xl mx-auto">{inV?.pricingSubheading ?? service.pricing.subheading}</p>
+                            )}
+                            {alternateUrl && (
+                                <div className="mt-7 inline-flex items-center rounded-full border border-border bg-background-secondary/60 p-1" role="group" aria-label="Pricing region">
+                                    {market === 'GLOBAL' ? (
+                                        <>
+                                            <span className="px-5 py-2 rounded-full text-sm font-bold bg-accent text-white shadow-button">
+                                                🌎 Global · USD
+                                            </span>
+                                            <Link
+                                                href={alternateUrl}
+                                                className="px-5 py-2 rounded-full text-sm font-bold text-foreground-secondary hover:text-foreground transition-all duration-300"
+                                            >
+                                                🇮🇳 India · INR
+                                            </Link>
+                                        </>
+                                    ) : (
+                                        <>
+                                            <Link
+                                                href={alternateUrl}
+                                                className="px-5 py-2 rounded-full text-sm font-bold text-foreground-secondary hover:text-foreground transition-all duration-300"
+                                            >
+                                                🌎 Global · USD
+                                            </Link>
+                                            <span className="px-5 py-2 rounded-full text-sm font-bold bg-accent text-white shadow-button">
+                                                🇮🇳 India · INR
+                                            </span>
+                                        </>
+                                    )}
+                                </div>
+                            )}
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-3 gap-6 items-stretch">
+                            {service.pricing.tiers.map((tier, i) => (
+                                <div
+                                    key={i}
+                                    className={`relative rounded-3xl p-8 flex flex-col transition-all duration-300 overflow-hidden ${tier.highlighted
+                                        ? 'border-2 border-accent bg-background-card shadow-[0_12px_50px_rgba(194,65,12,0.15)] md:scale-[1.03] z-10'
+                                        : 'border border-border bg-background-card shadow-card hover:border-accent/30 hover:shadow-card-hover'
+                                        }`}
+                                >
+                                    {tier.highlighted && (
+                                        <>
+                                            <div className="absolute top-0 left-0 right-0 h-1 bg-accent-gradient" />
+                                            <span className="absolute top-5 right-5 px-3 py-1 rounded-full bg-accent text-white text-[10px] font-black uppercase tracking-[0.15em]">
+                                                Most Popular
+                                            </span>
+                                        </>
+                                    )}
+                                    <h3 className="text-xl font-bold text-foreground mb-1">{tier.name}</h3>
+                                    {tier.tagline && <p className="text-foreground-secondary text-sm mb-6">{tier.tagline}</p>}
+                                    <div className="mb-7">
+                                        {tier.priceLabel && (
+                                            <p className="text-foreground-muted text-[10px] uppercase tracking-[0.2em] mb-2">{tier.priceLabel}</p>
+                                        )}
+                                        <p className="text-4xl md:text-[2.6rem] font-extrabold text-foreground leading-none transition-opacity duration-300">
+                                            {market === 'IN' && tier.priceIN ? tier.priceIN : tier.price}
+                                            {tier.period && <span className="text-sm font-medium text-foreground-secondary">{tier.period}</span>}
+                                        </p>
+                                    </div>
+                                    <ul className="space-y-3.5 text-left mb-8 flex-1">
+                                        {tier.features.map((item, j) => (
+                                            <li key={j} className="flex items-start gap-3 text-foreground-secondary text-sm">
+                                                <span className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full bg-accent/10 flex items-center justify-center">
+                                                    <svg width="11" height="11" viewBox="0 0 24 24" fill="none" className="text-accent"><path d="M20 6L9 17l-5-5" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" /></svg>
+                                                </span>
+                                                <span className="leading-relaxed">{item}</span>
+                                            </li>
+                                        ))}
+                                    </ul>
+                                    <Button
+                                        onClick={() => openModal(`Pricing - ${tier.name}`)}
+                                        variant={tier.highlighted ? 'primary' : 'secondary'}
+                                        size="md"
+                                        className="w-full justify-center"
+                                    >
+                                        {tier.buttonText}
+                                    </Button>
+                                </div>
+                            ))}
+                        </div>
+                        {(inV?.assurances ?? service.pricing.assurances) && (
+                            <div className="mt-10 flex flex-wrap items-center justify-center gap-x-8 gap-y-3 px-6 py-5 rounded-2xl border border-border bg-background-secondary/40">
+                                {(inV?.assurances ?? service.pricing.assurances)!.map((item, i) => (
+                                    <span key={i} className="flex items-center gap-2 text-foreground-secondary text-sm">
+                                        <svg width="13" height="13" viewBox="0 0 24 24" fill="none" className="text-accent flex-shrink-0"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" /></svg>
+                                        {item}
+                                    </span>
+                                ))}
+                            </div>
+                        )}
+                        {market === 'IN' && inV?.pricingNote && (
+                            <p className="mt-4 text-center text-foreground-muted text-xs tracking-wide">{inV.pricingNote}</p>
+                        )}
+                    </div>
+                </SectionWrapper>
+            )}
+
+            {/* Why Us */}
+            {service.whyUs && (
+                <SectionWrapper className="bg-background-secondary/30">
+                    <div className="max-w-5xl mx-auto">
+                        <div className="text-center mb-12">
+                            <SectionBadge label="Why Us" />
+                            <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">{service.whyUs.heading}</h2>
+                        </div>
+                        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
+                            {service.whyUs.items.map((item, i) => (
+                                <div key={i} className="rounded-2xl border border-border bg-background-card p-6 hover:border-accent/40 hover:shadow-card-hover transition-all duration-300 group">
+                                    <h3 className="text-lg font-bold text-foreground mb-2 group-hover:text-accent transition-colors">{item.title}</h3>
+                                    <p className="text-foreground-secondary text-sm leading-relaxed">{item.description}</p>
                                 </div>
                             ))}
                         </div>
@@ -162,7 +398,7 @@ export default function ServicePageClient({ service }: ServicePageClientProps) {
                 <div className="max-w-container mx-auto px-6 md:px-8 mt-16 mb-16 md:mb-24">
                     <div className="max-w-4xl mx-auto bg-background-secondary/30 rounded-3xl p-8 md:p-12 shadow-sm flex flex-col md:flex-row gap-8 items-center">
                         <div className="flex-1">
-                            <svg width="40" height="40" viewBox="0 0 24 24" fill="none" className="text-accent/30 mb-6"><path d="M10 11h-4a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2zm10 0h-4a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2zM10 15v-2a4 4 0 0 0-4-4H4a6 6 0 0 1 6 6zm10 0v-2a4 4 0 0 0-4-4h-2a6 6 0 0 1 6 6z" fill="currentColor"/></svg>
+                            <svg width="40" height="40" viewBox="0 0 24 24" fill="none" className="text-accent/30 mb-6"><path d="M10 11h-4a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2zm10 0h-4a2 2 0 0 1-2-2v-4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v4a2 2 0 0 1-2 2zM10 15v-2a4 4 0 0 0-4-4H4a6 6 0 0 1 6 6zm10 0v-2a4 4 0 0 0-4-4h-2a6 6 0 0 1 6 6z" fill="currentColor" /></svg>
                             <p className="text-xl md:text-2xl font-serif text-foreground leading-relaxed italic mb-6">&quot;{service.testimonial.quote}&quot;</p>
                             <div>
                                 <div className="font-bold text-foreground text-lg">{service.testimonial.author}</div>
@@ -176,20 +412,58 @@ export default function ServicePageClient({ service }: ServicePageClientProps) {
             {/* Tech Stack */}
             <SectionWrapper>
                 <div className="text-center mb-12">
-                    <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-4">The Tech Stack</h2>
-                    <p className="text-foreground-secondary">Modern tools for robust, scalable results.</p>
+                    <SectionBadge label="Tools & Stack" />
+                    <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">The Tech Stack</h2>
+                    <p className="text-foreground-secondary max-w-2xl mx-auto">Modern tools for robust, scalable results.</p>
                 </div>
                 <TechMarquee items={service.techStack} />
             </SectionWrapper>
 
+            {/* Comparison Table */}
+            {service.comparison && (
+                <SectionWrapper>
+                    <div className="max-w-4xl mx-auto">
+                        <div className="text-center mb-12">
+                            <SectionBadge label="The Difference" />
+                            <h2 className="text-3xl md:text-4xl font-bold text-foreground mb-4">{service.comparison.heading}</h2>
+                        </div>
+                        <div className="rounded-2xl border border-border overflow-hidden shadow-card">
+                            <div className="grid grid-cols-2">
+                                <div className="p-5 md:p-6 border-r border-border bg-red-500/5">
+                                    <span className="font-bold text-foreground-secondary text-xs uppercase tracking-[0.15em]">Typical Agency</span>
+                                </div>
+                                <div className="p-5 md:p-6 bg-accent/5">
+                                    <span className="font-bold text-accent text-xs uppercase tracking-[0.15em]">Our Approach</span>
+                                </div>
+                            </div>
+                            {service.comparison.rows.map((row, i, arr) => (
+                                <div key={i} className={`grid grid-cols-2 group hover:bg-background-secondary/20 transition-colors ${i !== arr.length - 1 ? 'border-b border-border' : ''}`}>
+                                    <div className="p-4 md:p-5 border-r border-border text-foreground-secondary text-sm md:text-base flex items-center gap-2">
+                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="text-red-500/50 flex-shrink-0 hidden md:block"><path d="M18 6L6 18M6 6l12 12" stroke="currentColor" strokeWidth="2" strokeLinecap="round" /></svg>
+                                        {row.typical}
+                                    </div>
+                                    <div className="p-4 md:p-5 text-foreground text-sm md:text-base font-medium flex items-center gap-2">
+                                        <svg width="14" height="14" viewBox="0 0 24 24" fill="none" className="text-accent flex-shrink-0 hidden md:block"><path d="M20 6L9 17l-5-5" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round" /></svg>
+                                        {row.ours}
+                                    </div>
+                                </div>
+                            ))}
+                        </div>
+                    </div>
+                </SectionWrapper>
+            )}
+
             {/* FAQs */}
             <SectionWrapper className="bg-background-secondary/30">
-                <div className="max-w-3xl mx-auto">
-                    <h2 className="text-2xl md:text-3xl font-bold text-foreground mb-12 text-center">Frequently Asked Questions</h2>
-                    <div className="space-y-8">
-                        {service.faqs.map((faq, i) => (
-                            <div key={i} className="bg-background rounded-xl p-6 border border-border">
-                                <h3 className="text-lg font-semibold text-foreground mb-3">{faq.question}</h3>
+                <div className="max-w-4xl mx-auto">
+                    <div className="text-center mb-12">
+                        <SectionBadge label="FAQ" />
+                        <h2 className="text-3xl md:text-4xl font-bold text-foreground">Frequently Asked Questions</h2>
+                    </div>
+                    <div className="space-y-5">
+                        {faqs.map((faq, i) => (
+                            <div key={i} className="bg-background rounded-2xl p-6 md:p-8 border border-border hover:border-accent/30 hover:shadow-card transition-all duration-300 group">
+                                <h3 className="text-lg font-semibold text-foreground mb-3 group-hover:text-accent transition-colors">{faq.question}</h3>
                                 <p className="text-foreground-secondary text-sm leading-relaxed">{faq.answer}</p>
                             </div>
                         ))}
@@ -199,21 +473,33 @@ export default function ServicePageClient({ service }: ServicePageClientProps) {
 
             {/* Final CTA */}
             <SectionWrapper className="text-center">
-                <div className="max-w-2xl mx-auto py-12 px-8 rounded-3xl bg-accent-gradient shadow-glow relative overflow-hidden">
+                <div className="max-w-3xl mx-auto py-14 px-8 rounded-3xl bg-accent-gradient shadow-glow relative overflow-hidden">
+                    {/* Decorative circles */}
+                    <div className="absolute -top-20 -right-20 w-60 h-60 rounded-full bg-white/5 pointer-events-none" />
+                    <div className="absolute -bottom-16 -left-16 w-48 h-48 rounded-full bg-white/5 pointer-events-none" />
                     <div className="relative z-10">
                         <h2 className="text-3xl md:text-4xl font-bold text-white mb-6">
                             {service.customCta ? service.customCta.title : 'Ready to transform your business?'}
                         </h2>
-                        <p className="text-white/80 text-lg mb-8 max-w-xl mx-auto">
-                            {service.customCta ? service.customCta.subtitle : `Let's discuss how we can build your next ${service.title.toLowerCase()}.`}
+                        <p className="text-white/90 text-lg mb-6 max-w-xl mx-auto">
+                            {inV?.ctaSubtitle ?? (service.customCta ? service.customCta.subtitle : `Let's discuss how we can build your next ${service.title.toLowerCase()}.`)}
                         </p>
-                        <Button 
-                            onClick={() => {
-                                trackConversion_StartProjectClick(`Service CTA - ${service.title}`);
-                                setIsModalOpen(true);
-                            }} 
-                            variant="primary" 
-                            size="lg" 
+                        {service.customCta?.bullets && (
+                            <ul className="text-white text-left max-w-md mx-auto mb-8 space-y-3">
+                                {service.customCta.bullets.map((bullet, i) => (
+                                    <li key={i} className="flex items-start gap-3">
+                                        <span className="mt-0.5 flex-shrink-0 w-5 h-5 rounded-full bg-white/20 flex items-center justify-center">
+                                            <svg width="10" height="10" viewBox="0 0 24 24" fill="none" className="text-white"><path d="M20 6L9 17l-5-5" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round" /></svg>
+                                        </span>
+                                        <span>{bullet}</span>
+                                    </li>
+                                ))}
+                            </ul>
+                        )}
+                        <Button
+                            onClick={() => openModal('Final')}
+                            variant="primary"
+                            size="lg"
                             className="!bg-neutral-950 !text-white !bg-none hover:!bg-black border border-white/10 hover:border-white/20 shadow-2xl transition-all font-bold group"
                         >
                             {service.customCta ? service.customCta.buttonText : 'Start a project'}

--- a/src/components/sections/Positioning.tsx
+++ b/src/components/sections/Positioning.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import SectionWrapper from '../SectionWrapper';
 
 const stats = [
-    { label: 'Avg. Experience', value: '3+ Years' },
+    { label: 'Avg. Experience', value: '4+ Years' },
     { label: 'Project Success', value: '100%' },
     { label: 'Senior Engineers', value: '10+' },
 ];

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -14,10 +14,58 @@ export interface ServiceDetail {
     faqs: { question: string; answer: string }[];
     metrics?: { value: string; label: string }[];
     hook?: string;
+    badge?: string;
+    problemHeading?: string;
+    problemSummary?: string;
+    processHeading?: string;
+    processSummary?: string;
+    subServices?: {
+        heading: string;
+        subheading?: string;
+        items: { title: string; intro?: string; points: string[] }[];
+    };
+    whyUs?: {
+        heading: string;
+        items: { title: string; description: string }[];
+    };
+    comparison?: {
+        heading: string;
+        rows: { typical: string; ours: string }[];
+    };
+    pricing?: {
+        heading: string;
+        subheading?: string;
+        tiers: {
+            name: string;
+            tagline?: string;
+            priceLabel?: string;
+            price: string;
+            priceIN?: string;
+            period?: string;
+            features: string[];
+            highlighted?: boolean;
+            buttonText: string;
+        }[];
+        assurances?: string[];
+    };
+    /**
+     * India-market variant, rendered as a separate crawlable page at
+     * /in/services/[slug] (hreflang en-IN). Indian visitors are geo-routed
+     * to it by middleware; crawlers index both versions independently.
+     */
+    marketIN?: {
+        seo?: { title: string; metaDescription: string };
+        hook?: string;
+        pricingSubheading?: string;
+        assurances?: string[];
+        ctaSubtitle?: string;
+        pricingNote?: string;
+        faqs?: { question: string; answer: string }[];
+    };
     process?: { title: string; description: string }[];
     targetAudience?: { for: string[]; notFor: string[] };
     testimonial?: { quote: string; author: string; role: string; avatar?: string };
-    customCta?: { title: string; subtitle: string; buttonText: string };
+    customCta?: { title: string; subtitle: string; buttonText: string; bullets?: string[] };
 }
 
 export const services: ServiceDetail[] = [
@@ -25,9 +73,202 @@ export const services: ServiceDetail[] = [
         slug: 'ai-agents-automation',
         title: 'Agentic AI & Intelligent Automation',
         description: 'Autonomous AI agents that reason, use tools, and execute complex workflows end-to-end — built on LangChain, LangGraph, RAG, and your own business data.',
+        badge: 'AI Agent Development',
+        hook: 'Automate the work that eats your team\'s week. We build autonomous AI agents that reason, use tools, and execute complete workflows on your own business data — safely, measurably, in production.',
+        metrics: [
+            { value: '2–6 wks', label: 'First agent in production' },
+            { value: '40–60%', label: 'Below US agency rates' },
+            { value: '100%', label: 'Code & IP ownership' },
+        ],
+        problemHeading: 'Why Most AI Initiatives Stall',
+        problemSummary: 'Result: AI stays a demo on someone\'s laptop while your team keeps scaling headcount instead of throughput.',
+        processHeading: 'Our Production AI Agent Framework',
+        processSummary: 'This is how AI agents become reliable digital workers — not another abandoned pilot.',
+        subServices: {
+            heading: 'Our AI Agent Development Services',
+            subheading: 'Everything you need to take AI from idea to a production system that pays for itself.',
+            items: [
+                {
+                    title: 'Custom AI Agent Development',
+                    intro: 'Agents built around your exact workflow:',
+                    points: ['Tool-using agents that call your APIs & databases', 'Human-in-the-loop checkpoints where it matters', 'Error recovery and escalation built in'],
+                },
+                {
+                    title: 'RAG & Knowledge Systems',
+                    intro: 'Your company knowledge, finally searchable:',
+                    points: ['Documents, tickets & wikis chunked and embedded', 'Pinecone, Qdrant, or pgvector retrieval layers', 'Grounded answers with citations — no hallucinated facts'],
+                },
+                {
+                    title: 'Multi-Agent Orchestration',
+                    intro: 'Complex workflows, decomposed and automated:',
+                    points: ['LangGraph & CrewAI orchestration', 'Planner, worker & reviewer agent patterns', 'State, memory & long-running task management'],
+                },
+                {
+                    title: 'AI Chatbots & Copilots',
+                    intro: 'Assistants that act, not just answer:',
+                    points: ['Customer support automation with real resolutions', 'In-product copilots for your SaaS', 'Slack, WhatsApp & web deployments'],
+                },
+                {
+                    title: 'LLM Integration & Fine-Tuning',
+                    intro: 'The right model for each job:',
+                    points: ['GPT, Claude, Gemini & open-source models', 'Fine-tuned & self-hosted models for privacy', 'Model routing & prompt caching for cost control'],
+                },
+                {
+                    title: 'Evaluation, Guardrails & AI Ops',
+                    intro: 'The part most agencies skip:',
+                    points: ['Automated eval suites before every release', 'Output validation & safety guardrails', 'Tracing, cost monitoring & feedback loops with LangSmith'],
+                },
+            ],
+        },
+        whyUs: {
+            heading: 'Why Companies Choose Brynex for AI Agents',
+            items: [
+                { title: 'Production-First, Not Demo-First', description: 'Evals, guardrails, and observability ship with every agent — so it keeps working after the launch call ends.' },
+                { title: 'ROI Mapped Before We Build', description: 'We quantify hours saved and cost per task up front, and rule out workflows where simple automation beats an agent.' },
+                { title: 'Model-Agnostic by Design', description: 'GPT, Claude, Gemini, or self-hosted open-source — chosen for your accuracy, privacy, and cost targets, never vendor lock-in.' },
+                { title: 'Your Data Stays Yours', description: 'Private VPC deployments, self-hosted models where required, and zero training on your proprietary data.' },
+                { title: 'Senior Engineers Only', description: '4+ years average experience. The engineers who scope your agent are the ones who build and ship it.' },
+            ],
+        },
+        comparison: {
+            heading: 'How We\'re Different from Typical AI Agencies',
+            rows: [
+                { typical: 'Impressive demos that break in production', ours: 'Evals, guardrails & monitoring from day one' },
+                { typical: 'A generic chatbot bolted onto your site', ours: 'Tool-using agents that execute real workflows' },
+                { typical: 'Locked into one model vendor', ours: 'Model-agnostic: GPT, Claude, Gemini, open-source' },
+                { typical: 'Black-box costs that balloon at scale', ours: 'Model routing & caching for predictable spend' },
+                { typical: 'Open-ended hourly billing', ours: 'Fixed-scope pilots mapped to measurable ROI' },
+            ],
+        },
+        pricing: {
+            heading: 'AI Agent Development Pricing',
+            subheading: 'Fixed-scope, milestone-billed projects — you know the full investment before we write a line of code:',
+            tiers: [
+                {
+                    name: 'Agent Pilot',
+                    tagline: 'Prove the ROI on one workflow',
+                    priceLabel: 'Starting at',
+                    price: '$4,999',
+                    priceIN: '₹49,999',
+                    period: '/project',
+                    features: [
+                        'One workflow automated end-to-end',
+                        'RAG over one knowledge source',
+                        'Evaluation suite & guardrails included',
+                        'Live in 2–4 weeks',
+                        '30 days of post-launch support',
+                    ],
+                    buttonText: 'Start with a Pilot',
+                },
+                {
+                    name: 'Production Agent System',
+                    tagline: 'The full automation engine',
+                    priceLabel: 'Starting at',
+                    price: '$12,999',
+                    priceIN: '₹1,49,999',
+                    period: '/project',
+                    highlighted: true,
+                    features: [
+                        'Multi-step, tool-using agent workflows',
+                        'API, database & CRM integrations',
+                        'Multi-agent orchestration with LangGraph',
+                        'Observability + cost monitoring dashboard',
+                        'Live in 6–10 weeks · 90 days support',
+                    ],
+                    buttonText: 'Scope My Agent System',
+                },
+                {
+                    name: 'Enterprise AI Automation',
+                    tagline: 'AI across departments, on your infrastructure',
+                    priceLabel: 'Custom scope',
+                    price: 'Custom',
+                    features: [
+                        'Multiple workflows & departments',
+                        'Private VPC or self-hosted models',
+                        'Fine-tuning on proprietary data',
+                        'SLAs & dedicated senior team',
+                        'Security review & compliance support',
+                    ],
+                    buttonText: 'Talk to an Architect',
+                },
+            ],
+            assurances: [
+                'Free discovery call & ROI mapping',
+                'NDA before we see your data',
+                'Milestone billing — pay as we deliver',
+                '100% code & IP ownership',
+            ],
+        },
+        marketIN: {
+            seo: {
+                title: 'AI Agent Development Company in India | Pilots from ₹49,999',
+                metaDescription: 'AI agent development in India — pilots from ₹49,999, production agent systems from ₹1,49,999. LangChain, RAG & guardrails for Indian startups & enterprises. GST invoicing, free consultation.',
+            },
+            hook: 'Automate the work that eats your team\'s week. Production-grade AI agents for Indian startups, D2C brands, and enterprises — built on your own business data, at pricing that makes sense for the Indian market.',
+            pricingSubheading: 'Honest Indian-market pricing — fixed scope, milestone billed, GST invoice included:',
+            assurances: [
+                'Free discovery call & ROI mapping',
+                'GST invoicing & INR payments (UPI/bank)',
+                'Milestone billing — pay as we deliver',
+                '100% code & IP ownership',
+            ],
+            ctaSubtitle: 'Book a free use-case mapping call — in English or Hindi. We\'ll tell you honestly which workflows are agent-ready, and which aren\'t worth your money yet.',
+            pricingNote: 'Prices for the Indian market · GST extra · INR invoicing',
+            faqs: [
+                {
+                    question: 'How much does AI agent development cost in India?',
+                    answer: 'An AI agent pilot that automates one workflow starts at ₹49,999. Production agent systems with API integrations and multi-agent orchestration start at ₹1,49,999, and enterprise automation across departments is custom-scoped. Every project gets a fixed quote after a free discovery call — GST extra, milestone billing in INR.',
+                },
+                {
+                    question: 'Is my business data safe with AI agents?',
+                    answer: 'Yes. We deploy in private VPCs, use self-hosted open-source models where required, and ensure no data is ever used to train public models.',
+                },
+                {
+                    question: 'Can AI agents really handle complex, multi-step tasks?',
+                    answer: 'Modern agentic systems built on LangGraph can plan, use external tools and APIs, recover from errors, and escalate to humans — reliably executing workflows that used to need a person at every step.',
+                },
+                {
+                    question: 'Which models and frameworks do you work with?',
+                    answer: 'We\'re framework-agnostic but typically build on LangChain, LangGraph, and CrewAI, using GPT, Claude, Gemini, or fine-tuned Hugging Face models — paired with vector databases like Pinecone, Qdrant, or pgvector for RAG.',
+                },
+                {
+                    question: 'Do you work with startups and enterprises across India?',
+                    answer: 'Yes — we work remote-first with startups, D2C brands, and enterprises across Bangalore, Mumbai, Delhi NCR, Pune, Hyderabad, and the rest of India. Calls in English or Hindi, GST invoicing, and INR payments via UPI or bank transfer.',
+                },
+                {
+                    question: 'How long does it take to launch an AI agent?',
+                    answer: 'A pilot goes live in 2–4 weeks; production agent systems with integrations and guardrails take 6–10 weeks. You see working demos every week from the first sprint.',
+                },
+            ],
+        },
+        targetAudience: {
+            for: [
+                'Teams drowning in repetitive, multi-step manual workflows',
+                'Companies scaling customer support without wanting to scale headcount',
+                'Businesses with knowledge trapped in documents, tickets, and wikis',
+                'SaaS products adding AI features their competitors don\'t have',
+                'US, UK, Australia & India companies wanting senior AI talent at sane rates',
+            ],
+            notFor: [
+                'You want a generic chatbot live by Friday',
+                'There\'s no real workflow or data for the agent to work with',
+                'You expect AI magic without measurement or iteration',
+                'You\'re not ready to involve a process owner from your team',
+            ],
+        },
+        customCta: {
+            title: 'Ready to Put AI Agents to Work?',
+            subtitle: 'Book a free use-case mapping call. We\'ll tell you honestly which workflows are agent-ready — and which aren\'t.',
+            buttonText: 'Map Your AI Use Case — Free',
+            bullets: [
+                'A workflow automated end-to-end (not a demo)',
+                'Grounded answers on your own business data',
+                'Evals, guardrails & cost monitoring included',
+            ],
+        },
         seo: {
-            title: 'AI Agent Development & Intelligent Automation | Brynex Labs',
-            metaDescription: 'Production-grade AI agents built with LangChain, LangGraph, RAG, and vector databases. Automate support, operations, and data workflows with autonomous, tool-using agents.',
+            title: 'AI Agent Development Company | Agentic AI & Automation Services',
+            metaDescription: 'Brynex Labs is an AI agent development company serving the USA & India. Production-grade AI agents with LangChain, LangGraph, RAG & vector databases — automate support, operations & workflows.',
         },
         challenges: [
             'Excessive time spent on repetitive, multi-step manual workflows',
@@ -91,15 +332,216 @@ export const services: ServiceDetail[] = [
                 question: 'How much does it cost to run AI agents in production?',
                 answer: 'Costs depend on usage and model selection. We optimize with model routing, prompt caching, and right-sized open-source models to keep operational costs predictable and low.',
             },
+            {
+                question: 'How much does AI agent development cost?',
+                answer: 'A focused single-workflow pilot starts at $4,999, production agent systems with integrations and multi-agent orchestration start at $12,999, and enterprise automation across departments is custom-scoped. Every project gets a fixed quote after a free discovery call — our India-based senior team delivers at 40–60% below US agency rates.',
+            },
+            {
+                question: 'Do you build AI agents for companies in the USA and other countries?',
+                answer: 'Yes. We work with clients across the USA, UK, Australia, and India with significant timezone overlap, async-first communication, and contracts/invoicing in USD. Most of our AI agent projects are for US-based SaaS and enterprise teams.',
+            },
         ],
     },
     {
         slug: 'ai-native-software-engineering',
         title: 'AI-Native Software Engineering',
         description: 'Full-cycle product engineering — custom software, SaaS platforms, web & mobile apps, cloud infrastructure, and legacy modernization — built AI-first for speed and scale.',
+        badge: 'Custom Software & SaaS Development',
+        hook: 'Your product, engineered for scale. Full-cycle custom software — SaaS platforms, web & mobile apps, and cloud infrastructure — shipped by senior engineers at AI-accelerated speed.',
+        metrics: [
+            { value: '8–12 wks', label: 'MVP to production' },
+            { value: '40–60%', label: 'Below US agency rates' },
+            { value: '100%', label: 'Code & IP ownership' },
+        ],
+        problemHeading: 'Why Software Projects Go Sideways',
+        problemSummary: 'Result: slow roadmaps, rising maintenance costs, and products losing ground to faster competitors.',
+        processHeading: 'Our AI-Accelerated Delivery Framework',
+        processSummary: 'This is how a lean senior team ships enterprise-grade software at twice the usual pace.',
+        subServices: {
+            heading: 'Our Software Engineering Services',
+            subheading: 'One senior team across the full product lifecycle — no fragmented vendors.',
+            items: [
+                {
+                    title: 'Custom Software Development',
+                    intro: 'Software that fits your business exactly:',
+                    points: ['Internal tools, dashboards & APIs', 'Workflow systems off-the-shelf software can\'t match', 'Discovery-to-deployment under one roof'],
+                },
+                {
+                    title: 'SaaS Product Engineering',
+                    intro: 'Platforms built to sell from day one:',
+                    points: ['Multi-tenant architecture with data isolation', 'Subscription billing with Stripe', 'Enterprise-grade auth & security'],
+                },
+                {
+                    title: 'Web & Mobile App Development',
+                    intro: 'High-performance apps on every screen:',
+                    points: ['Next.js web apps tuned for Core Web Vitals', 'React Native & Flutter cross-platform mobile', 'Pixel-perfect, conversion-focused UI'],
+                },
+                {
+                    title: 'Cloud & DevOps Engineering',
+                    intro: 'Infrastructure that scales with you:',
+                    points: ['AWS, GCP & Azure architecture', 'Infrastructure as Code with Terraform', 'Zero-downtime CI/CD pipelines'],
+                },
+                {
+                    title: 'Application Modernization',
+                    intro: 'Legacy to modern, without the risk:',
+                    points: ['Strangler-pattern phased migrations', 'Old and new systems running in parallel', 'Zero-downtime, low-risk cutovers'],
+                },
+                {
+                    title: 'Embedded AI Features',
+                    intro: 'AI where it creates real leverage:',
+                    points: ['Intelligent search & personalization', 'Automated workflows inside your product', 'Built AI-native, not bolted on later'],
+                },
+            ],
+        },
+        whyUs: {
+            heading: 'Why Companies Build with Brynex Labs',
+            items: [
+                { title: 'Senior Engineers Only', description: '4+ years average experience — no juniors learning on your budget, no bait-and-switch after the sales call.' },
+                { title: 'AI-Accelerated Sprints', description: 'AI-assisted engineering lets a lean senior team ship at twice the pace — you pay for outcomes, not headcount.' },
+                { title: 'Zero Middlemen', description: 'Direct access to the engineers building your product. Decisions happen in one conversation, not three handoffs.' },
+                { title: 'Fixed Scope, Respected Budget', description: 'Fixed-scope proposals with milestone billing. If a feature isn\'t worth building, we\'ll tell you before you pay for it.' },
+                { title: 'Hardened for Production', description: 'Automated tests, security hardening, and zero-downtime deploys are the default — not a premium add-on.' },
+            ],
+        },
+        comparison: {
+            heading: 'How We\'re Different from Typical Dev Shops',
+            rows: [
+                { typical: 'Junior-heavy teams behind a senior salesperson', ours: 'Senior engineers from the first call to the last commit' },
+                { typical: 'Open-ended hourly billing', ours: 'Fixed-scope proposals with milestone billing' },
+                { typical: 'Layers of PMs between you and the code', ours: 'Direct engineer access with weekly demos' },
+                { typical: '"Works on demo day", breaks in production', ours: 'Automated tests, CI/CD & security hardening built in' },
+                { typical: 'AI bolted on as an afterthought', ours: 'AI-native architecture from the first design doc' },
+            ],
+        },
+        pricing: {
+            heading: 'Custom Software Development Pricing',
+            subheading: 'Transparent, fixed-scope pricing — know your full investment before development starts:',
+            tiers: [
+                {
+                    name: 'Launch MVP',
+                    tagline: 'Validate fast with a real product',
+                    priceLabel: 'Starting at',
+                    price: '$9,999',
+                    priceIN: '₹99,999',
+                    period: '/project',
+                    features: [
+                        'Core feature set, production-ready',
+                        'Next.js web app with polished UI',
+                        'Auth, database & cloud deployment',
+                        'Live in 6–10 weeks',
+                        '30 days of post-launch support',
+                    ],
+                    buttonText: 'Scope My MVP',
+                },
+                {
+                    name: 'SaaS Platform',
+                    tagline: 'Built to onboard paying customers',
+                    priceLabel: 'Starting at',
+                    price: '$24,999',
+                    priceIN: '₹2,49,999',
+                    period: '/project',
+                    highlighted: true,
+                    features: [
+                        'Multi-tenant architecture & data isolation',
+                        'Stripe subscription billing & admin panel',
+                        'Web + mobile (React Native) options',
+                        'CI/CD, automated tests & monitoring',
+                        'Live in 3–5 months · 90 days support',
+                    ],
+                    buttonText: 'Plan My Platform',
+                },
+                {
+                    name: 'Enterprise & Modernization',
+                    tagline: 'Legacy to modern, without downtime',
+                    priceLabel: 'Custom scope',
+                    price: 'Custom',
+                    features: [
+                        'Phased strangler-pattern migration',
+                        'Dedicated senior engineering team',
+                        'Cloud architecture & DevOps overhaul',
+                        'SLAs, security review & compliance',
+                        'Zero-downtime cutovers',
+                    ],
+                    buttonText: 'Talk to an Architect',
+                },
+            ],
+            assurances: [
+                'Free discovery call & architecture review',
+                'Fixed quote within 72 hours',
+                'Weekly demos — see progress every sprint',
+                '100% code & IP ownership',
+            ],
+        },
+        marketIN: {
+            seo: {
+                title: 'Custom Software Development Company in India | MVP from ₹99,999',
+                metaDescription: 'Custom software & SaaS development in India — MVPs from ₹99,999, multi-tenant SaaS platforms from ₹2,49,999. Senior engineers, fixed-scope quotes, GST invoicing. Free consultation.',
+            },
+            hook: 'Your product, engineered for scale. SaaS platforms, web & mobile apps, and cloud infrastructure for Indian startups and businesses — senior engineers, global quality, Indian-market pricing.',
+            pricingSubheading: 'Honest Indian-market pricing — fixed scope, weekly demos, GST invoice included:',
+            assurances: [
+                'Free discovery call & architecture review',
+                'Fixed quote within 72 hours',
+                'GST invoicing & INR payments (UPI/bank)',
+                '100% code & IP ownership',
+            ],
+            ctaSubtitle: 'Tell us what you\'re building — in English or Hindi. You\'ll get a senior engineer\'s honest assessment and a fixed-scope INR quote within 72 hours.',
+            pricingNote: 'Prices for the Indian market · GST extra · INR invoicing',
+            faqs: [
+                {
+                    question: 'How much does custom software development cost in India?',
+                    answer: 'A production-ready MVP starts at ₹99,999, full multi-tenant SaaS platforms at ₹2,49,999, and enterprise modernization is custom-scoped. You get a fixed-scope quote within 72 hours of a free discovery call — GST extra, milestone billing in INR.',
+                },
+                {
+                    question: 'What types of software do you build?',
+                    answer: 'Everything from custom internal tools and APIs to multi-tenant SaaS platforms, high-performance websites, and cross-platform mobile apps — plus the cloud infrastructure that runs them.',
+                },
+                {
+                    question: 'How long does a typical project take?',
+                    answer: 'A Minimum Viable Product (MVP) usually takes 6-10 weeks. Larger platforms or enterprise modernizations run 4-6+ months, delivered in increments so you see progress every sprint.',
+                },
+                {
+                    question: 'Can you modernize our existing legacy application?',
+                    answer: 'Yes. We typically use the "Strangler Pattern" to migrate functionality piece-by-piece, running old and new systems in parallel for zero-downtime, low-risk migrations.',
+                },
+                {
+                    question: 'Do you work with Indian startups and SMEs?',
+                    answer: 'Yes — Indian startups, D2C brands, and SMEs are a core part of our client base. We work remote-first across Bangalore, Mumbai, Delhi NCR, Pune, Hyderabad, and all of India, with calls in English or Hindi, GST invoicing, and INR payments via UPI or bank transfer.',
+                },
+                {
+                    question: 'Will I own the source code and IP?',
+                    answer: '100%. Upon project completion and final payment, all intellectual property, design assets, and source code are fully transferred to you — delivered into your own repositories from day one.',
+                },
+            ],
+        },
+        targetAudience: {
+            for: [
+                'Founders building a new SaaS product or MVP',
+                'Enterprises modernizing slow, expensive legacy systems',
+                'Teams tired of juggling separate web, mobile, and cloud vendors',
+                'US & European companies wanting offshore quality without offshore chaos',
+                'Products that need AI capabilities designed in, not bolted on',
+            ],
+            notFor: [
+                'You\'re shopping purely for the cheapest possible freelancer',
+                'The project is spec\'d as a one-week throwaway',
+                'No decision-maker can join discovery and weekly demos',
+                'You expect a big-bang rewrite with no phased delivery',
+            ],
+        },
+        customCta: {
+            title: 'Ready to Build Production-Grade Software?',
+            subtitle: 'Tell us what you\'re building. You\'ll get a senior engineer\'s honest assessment and a fixed-scope proposal within 72 hours.',
+            buttonText: 'Get Your Proposal — Free',
+            bullets: [
+                'A senior team shipping weekly from day one',
+                'Fixed-scope pricing with full IP transfer',
+                'Architecture built for the next 5 years, not the demo',
+            ],
+        },
         seo: {
-            title: 'AI-Native Software Engineering Services | Brynex Labs',
-            metaDescription: 'End-to-end AI-native software engineering: custom development, multi-tenant SaaS platforms, web & mobile apps, cloud & DevOps, and application modernization under one roof.',
+            title: 'Custom Software Development Company | SaaS, Web & Mobile Apps',
+            metaDescription: 'Custom software development company for startups & enterprises in the USA and India — multi-tenant SaaS platforms, web & mobile apps, cloud & DevOps, and application modernization under one roof.',
         },
         challenges: [
             'Off-the-shelf software doesn\'t fit your unique business needs',
@@ -167,6 +609,14 @@ export const services: ServiceDetail[] = [
                 question: 'How long does a typical project take?',
                 answer: 'A Minimum Viable Product (MVP) usually takes 8-12 weeks. Larger platforms or enterprise modernizations run 4-6+ months, delivered in increments so you see progress every sprint.',
             },
+            {
+                question: 'How much does custom software development cost?',
+                answer: 'A production-ready MVP starts at $9,999, full multi-tenant SaaS platforms at $24,999, and enterprise modernization is custom-scoped. Because our senior engineering team operates from India serving US and global clients, you get top-tier quality at 40–60% below typical US agency rates — with fixed-scope quotes, not open-ended hourly billing.',
+            },
+            {
+                question: 'Can US and European companies outsource software development to you?',
+                answer: 'Yes — most of our clients are in the USA and Europe. We provide overlapping working hours, daily async updates, US-style contracts with NDA and full IP transfer, and a single senior point of contact, making offshore development feel like an in-house team.',
+            },
         ],
     },
     {
@@ -177,8 +627,8 @@ export const services: ServiceDetail[] = [
         description: 'Turn Organic Traffic into Pipeline, Demo Requests & Revenue. We help B2B SaaS companies turn SEO into a predictable revenue channel—not just a traffic source.',
         hook: 'Turn Organic Traffic into Pipeline, Demo Requests & Revenue. We help B2B SaaS companies turn SEO into a predictable revenue channel—not just a traffic source.',
         seo: {
-            title: 'SaaS SEO Services for B2B Companies | Revenue-Focused SEO Agency',
-            metaDescription: 'Turn SEO into a predictable revenue channel. We help B2B SaaS companies drive demo requests, pipeline, and growth with revenue-focused SEO strategies.',
+            title: 'SaaS SEO Agency | B2B SaaS SEO Services That Drive Pipeline',
+            metaDescription: 'Brynex Labs is a SaaS SEO agency for B2B companies in the USA & India. We turn organic traffic into demo requests, pipeline & MRR with BOFU keywords, programmatic SEO, and CRO.',
         },
         challenges: [
             'Traffic growth without mapping to demo conversions',
@@ -221,6 +671,14 @@ export const services: ServiceDetail[] = [
             {
                 question: 'What makes your approach different?',
                 answer: 'We connect SEO directly to pipeline and revenue, not just rankings.',
+            },
+            {
+                question: 'How much do SaaS SEO services cost?',
+                answer: 'Engagements typically start at $1,500–$3,000/month for growth-stage SaaS companies and scale with scope. Every plan ties deliverables to pipeline metrics — demo requests and signups — not vanity traffic.',
+            },
+            {
+                question: 'Do you work with SaaS companies outside India?',
+                answer: 'Yes — we work with B2B SaaS companies in the USA, UK, Australia, and India. Strategy, content, and reporting are built for the market you sell into, including US-specific keyword and competitor research.',
             },
         ],
         process: [

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -153,7 +153,55 @@ export async function middleware(request: NextRequest) {
         return NextResponse.redirect(loginUrl);
     }
 
-    return NextResponse.next();
+    // ----- Geo-routed service pages -----
+    // Indian visitors get the crawlable /in/* variant (INR pricing, India copy);
+    // everyone else stays on the global version. Crawlers are never redirected —
+    // both variants are static, self-canonical, and paired via hreflang, so
+    // Google/GSC index them independently and serve the right one per country.
+    const country = request.headers.get('x-vercel-ip-country') ?? '';
+    const geoServiceMatch = pathname.match(
+        /^\/services\/(ai-agents-automation|ai-native-software-engineering)$/
+    );
+
+    if (geoServiceMatch) {
+        // "Global · USD" toggle on the India page: remember the choice, serve global.
+        if (request.nextUrl.searchParams.get('intl') === '1') {
+            const url = request.nextUrl.clone();
+            url.searchParams.delete('intl');
+            const res = NextResponse.redirect(url, 302);
+            res.cookies.set('bx-geo-optout', '1', { path: '/', maxAge: 60 * 60 * 24 * 90, sameSite: 'lax' });
+            return res;
+        }
+
+        const ua = request.headers.get('user-agent') ?? '';
+        // Search + AI crawlers (ChatGPT, Claude, Perplexity, Gemini, …) must
+        // never be geo-redirected — they index the canonical hreflang pages.
+        const isBot = /bot|crawler|spider|crawling|slurp|bingpreview|facebookexternalhit|embedly|pinterest|whatsapp|telegrambot|linkedinbot|twitterbot|gptbot|chatgpt|oai-search|claude|anthropic|perplexity|cohere|meta-external|duckassist|google-extended|googleother|bytespider/i.test(ua);
+        const optedOut = request.cookies.get('bx-geo-optout')?.value === '1';
+
+        if (country === 'IN' && !isBot && !optedOut) {
+            const url = request.nextUrl.clone();
+            url.pathname = `/in${pathname}`;
+            return NextResponse.redirect(url, 302);
+        }
+    }
+
+    const response = NextResponse.next();
+
+    // Choosing the India version re-enables auto geo-routing.
+    if (pathname.startsWith('/in/services/') && request.cookies.get('bx-geo-optout')) {
+        response.cookies.delete('bx-geo-optout');
+    }
+
+    // Geo hint cookie for analytics / future client-side personalization.
+    if (country && request.cookies.get('bx-country')?.value !== country) {
+        response.cookies.set('bx-country', country, {
+            path: '/',
+            maxAge: 60 * 60 * 24 * 30,
+            sameSite: 'lax',
+        });
+    }
+    return response;
 }
 
 export const config = {


### PR DESCRIPTION
On-page SEO (USA + India targeting):
- Rewrite titles/descriptions on all public pages with hook-style, keyword-first copy ("Software Company for AI Agents, Automation & SaaS SEO | Brynex Labs" as site default)
- Upgrade homepage JSON-LD: Organization+ProfessionalService with areaServed (US/IN/UK/AU/CA), OfferCatalog of the 3 services, real FAQPage; drop the unimplemented SearchAction
- Service pages emit Service + BreadcrumbList + FAQPage schema
- Fix sitemap gaps (case studies, new pages); googleBot directives, keywords, and category in root metadata; refresh OG image copy

New BOFU landing pages (framed as entry points to the 3 services):
- /hire-ai-developers and /ai-development-company-in-india with unique content, FAQ/Breadcrumb schema, footer links, sitemap entries

Service page redesign (AI agents + software engineering):
- SaaS-SEO-grade layout: hero glow + badge, metrics bar, problem/ solution cards, 6-card sub-service grids, framework timeline, ideal-fit/not-fit, why-us grid, comparison table, FAQ cards
- 3-tier pricing with realistic entry points (AI pilot $4,999, production $12,999; MVP $9,999, SaaS platform $24,999) plus assurance strip; per-tier GA4 conversion tracking
- Standardize experience claims to 4+ years site-wide

Geo-routed India variants (SEO-safe, crawlable):
- New static pages /in/services/[slug] with INR pricing (₹49,999 / ₹1,49,999 / ₹99,999 / ₹2,49,999), India copy, India FAQs, and Offer schema in INR
- hreflang en-IN/en-US/x-default pairs, self-canonical both sides, both versions in sitemap
- Middleware 302s Indian visitors to /in/* (bots never redirected; ?intl=1 opt-out cookie; toggle links between versions)

AI-search (GEO) readiness:
- robots.txt: explicit allow rules for GPTBot, OAI-SearchBot, ChatGPT-User, ClaudeBot, PerplexityBot, Google-Extended, Bingbot, Applebot, CCBot, and other AI crawlers
- /llms.txt describing services, pricing, and key URLs for LLMs
- Middleware bot regex extended so AI agents always get canonical pages

Docs: docs/seo/KEYWORD-STRATEGY.md (keyword->page map, content plan) and docs/seo/OFF-PAGE-SEO-PLAYBOOK.md (phased off-page/GEO guide)