### PR TITLE
feat(leads): automated enrichment — geo, engagement, email intel & lead scoring

### DIFF
--- a/src/app/api/contact/route.ts
+++ b/src/app/api/contact/route.ts
@@ -2,9 +2,19 @@ import { NextResponse } from 'next/server';
 import { emailService } from '@/lib/email';
 import { contactEmailTemplate } from '@/lib/templates/contact-email';
 import { saveSubmission, recordEmailResult } from '@/lib/contactStore';
+import { deriveCountry, emailMeta, computeLeadScore } from '@/lib/leadEnrichment';
 import { isDbConfigured } from '@/lib/mongodb';
 
 export const runtime = 'nodejs';
+
+/** Vercel geo headers arrive URI-encoded (e.g. "S%C3%A3o%20Paulo"). */
+const safeDecode = (value: string): string => {
+    try {
+        return decodeURIComponent(value);
+    } catch {
+        return value;
+    }
+};
 
 const NOTIFY_EMAIL =
     process.env.CONTACT_NOTIFY_EMAIL ||
@@ -30,7 +40,7 @@ export async function POST(request: Request) {
     const timezone = cap(body.timezone, 60) || 'Unknown';
     const sourcePath = cap(body.source, 200);
 
-    // First-touch marketing attribution (client-captured) + geo (edge header).
+    // First-touch marketing attribution (client-captured) + geo (edge headers).
     const attribution = (body.attribution ?? {}) as Record<string, unknown>;
     const utmSource = cap(attribution.utmSource, 120);
     const utmMedium = cap(attribution.utmMedium, 120);
@@ -39,7 +49,40 @@ export async function POST(request: Request) {
     const utmContent = cap(attribution.utmContent, 160);
     const referrer = cap(attribution.referrer, 300);
     const landingPage = cap(attribution.landingPage, 200);
-    const country = cap(request.headers.get('x-vercel-ip-country'), 8);
+
+    // Geo: Vercel edge headers, with phone/timezone fallbacks for country.
+    const headerCountry = cap(request.headers.get('x-vercel-ip-country'), 8);
+    const country = deriveCountry(headerCountry, phone, timezone);
+    const city = safeDecode(cap(request.headers.get('x-vercel-ip-city'), 80));
+    const region = safeDecode(cap(request.headers.get('x-vercel-ip-country-region'), 80));
+    const ip = cap(request.headers.get('x-forwarded-for'), 100).split(',')[0].trim();
+    const language = cap(request.headers.get('accept-language'), 120).split(',')[0].trim();
+
+    // Session engagement (client-tracked) — capped defensively.
+    const engagement = (body.engagement ?? {}) as Record<string, unknown>;
+    const pagesVisited = Array.isArray(engagement.pagesVisited)
+        ? engagement.pagesVisited.filter((p): p is string => typeof p === 'string').map((p) => p.slice(0, 200)).slice(0, 25)
+        : [];
+    const pageCount = typeof engagement.pageCount === 'number' && Number.isFinite(engagement.pageCount)
+        ? Math.min(Math.max(0, Math.round(engagement.pageCount)), 1000)
+        : pagesVisited.length;
+    const sessionSeconds = typeof engagement.sessionSeconds === 'number' && Number.isFinite(engagement.sessionSeconds)
+        ? Math.min(Math.max(0, Math.round(engagement.sessionSeconds)), 86_400)
+        : 0;
+
+    // Automated enrichment + scoring.
+    const { emailType, companyDomain } = emailMeta(email);
+    const leadScore = computeLeadScore({
+        emailType,
+        hasPhone: Boolean(phone),
+        projectDetailsLength: projectDetails.length,
+        pageCount,
+        sessionSeconds,
+        sourcePath: sourcePath || undefined,
+        landingPage: landingPage || undefined,
+        hasUtm: Boolean(utmSource),
+        country,
+    });
 
     if (!name || !email || !date || !time) {
         return NextResponse.json({ error: 'Missing required fields' }, { status: 400 });
@@ -70,6 +113,16 @@ export async function POST(request: Request) {
                 referrer: referrer || undefined,
                 landingPage: landingPage || undefined,
                 country: country || undefined,
+                city: city || undefined,
+                region: region || undefined,
+                ip: ip || undefined,
+                language: language || undefined,
+                pagesVisited: pagesVisited.length > 0 ? pagesVisited : undefined,
+                pageCount: pageCount || undefined,
+                sessionSeconds: sessionSeconds || undefined,
+                emailType,
+                companyDomain,
+                leadScore,
             });
             submissionId = submission.id;
         } catch (err) {

--- a/src/components/Analytics.tsx
+++ b/src/components/Analytics.tsx
@@ -4,7 +4,7 @@
 import Script from 'next/script';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { useEffect, Suspense } from 'react';
-import { captureAttribution } from '@/lib/attribution';
+import { captureAttribution, recordPageVisit } from '@/lib/attribution';
 
 function AnalyticsInner() {
     const pathname = usePathname();
@@ -18,6 +18,11 @@ function AnalyticsInner() {
     useEffect(() => {
         captureAttribution();
     }, []);
+
+    // Engagement trail (pages visited + time on site) for lead scoring.
+    useEffect(() => {
+        if (pathname) recordPageVisit(pathname);
+    }, [pathname]);
 
     // Track pageviews automatically
     useEffect(() => {

--- a/src/components/ContactForm.tsx
+++ b/src/components/ContactForm.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react';
 import { api } from '@/lib/api';
-import { getAttribution } from '@/lib/attribution';
+import { getAttribution, getEngagement } from '@/lib/attribution';
 import { PhoneInput } from 'react-international-phone';
 import 'react-international-phone/style.css';
 
@@ -43,6 +43,7 @@ export default function ContactForm({ onSuccess, className = '', isModal = false
                 timezone: userTimezone,
                 source: typeof window !== 'undefined' ? window.location.pathname : undefined,
                 attribution: getAttribution(),
+                engagement: getEngagement(),
             });
 
             setStep('success');

--- a/src/components/admin/LeadsList.tsx
+++ b/src/components/admin/LeadsList.tsx
@@ -14,7 +14,7 @@ function Spinner({ className = '' }: { className?: string }) {
 }
 
 type StatusFilter = 'all' | 'new' | 'contacted' | 'qualified' | 'proposal' | 'won' | 'lost';
-type SortOrder = 'newest' | 'oldest' | 'followup' | 'value';
+type SortOrder = 'newest' | 'oldest' | 'followup' | 'value' | 'score';
 
 const PIPELINE: LeadStatus[] = ['new', 'contacted', 'qualified', 'proposal', 'won', 'lost'];
 
@@ -73,6 +73,20 @@ function todayISO(): string {
     return new Date().toISOString().slice(0, 10);
 }
 
+function scoreBadge(score?: number): { label: string; classes: string } | null {
+    if (score === undefined) return null;
+    if (score >= 70) return { label: `🔥 Hot · ${score}`, classes: 'bg-orange-500/10 text-orange-500 border-orange-500/30' };
+    if (score >= 40) return { label: `Warm · ${score}`, classes: 'bg-amber-500/10 text-amber-500 border-amber-500/30' };
+    return { label: `Cold · ${score}`, classes: 'bg-background-secondary text-foreground-muted border-border' };
+}
+
+function formatDuration(seconds?: number): string {
+    if (!seconds) return '—';
+    const m = Math.floor(seconds / 60);
+    const s = seconds % 60;
+    return m > 0 ? `${m}m ${s}s` : `${s}s`;
+}
+
 function isOverdue(lead: ContactSubmission): boolean {
     return Boolean(
         lead.followUpAt &&
@@ -88,13 +102,17 @@ function escapeCsv(value: unknown): string {
 
 function exportCsv(leads: ContactSubmission[]) {
     const headers = [
-        'Name', 'Email', 'Phone', 'Status', 'Priority', 'Deal Value (USD)', 'Follow-up',
-        'Preferred Slot', 'Timezone', 'Country', 'Source Page', 'Landing Page', 'Referrer',
+        'Name', 'Email', 'Email Type', 'Company Domain', 'Phone', 'Status', 'Lead Score', 'Priority',
+        'Deal Value (USD)', 'Follow-up', 'Preferred Slot', 'Timezone', 'Country', 'City', 'Region',
+        'Language', 'Pages Visited', 'Session Seconds', 'Source Page', 'Landing Page', 'Referrer',
         'UTM Source', 'UTM Medium', 'UTM Campaign', 'Project Details', 'Submitted', 'Notes',
     ];
     const rows = leads.map((l) => [
-        l.name, l.email, l.phone ?? '', l.status, l.priority ? 'yes' : '', l.value ?? '',
-        l.followUpAt ?? '', `${l.preferredDate} ${l.preferredTime}`, l.timezone, l.country ?? '',
+        l.name, l.email, l.emailType ?? '', l.companyDomain ?? '', l.phone ?? '', l.status,
+        l.leadScore ?? '', l.priority ? 'yes' : '', l.value ?? '',
+        l.followUpAt ?? '', `${l.preferredDate} ${l.preferredTime}`, l.timezone,
+        l.country ?? '', l.city ?? '', l.region ?? '', l.language ?? '',
+        (l.pagesVisited ?? []).join(' > '), l.sessionSeconds ?? '',
         l.sourcePath ?? '', l.landingPage ?? '', l.referrer ?? '',
         l.utmSource ?? '', l.utmMedium ?? '', l.utmCampaign ?? '',
         l.projectDetails ?? '', l.createdAt,
@@ -191,6 +209,7 @@ export default function LeadsList({ initialLeads }: { initialLeads: ContactSubmi
             switch (sortOrder) {
                 case 'oldest': return a.createdAt.localeCompare(b.createdAt);
                 case 'value': return (b.value ?? 0) - (a.value ?? 0);
+                case 'score': return (b.leadScore ?? -1) - (a.leadScore ?? -1);
                 case 'followup': {
                     const av = a.followUpAt ?? '9999-12-31';
                     const bv = b.followUpAt ?? '9999-12-31';
@@ -349,6 +368,7 @@ export default function LeadsList({ initialLeads }: { initialLeads: ContactSubmi
                         <option value="oldest">Oldest first</option>
                         <option value="followup">Follow-up due</option>
                         <option value="value">Highest value</option>
+                        <option value="score">Hottest leads</option>
                     </select>
                     <button
                         type="button"
@@ -428,11 +448,26 @@ export default function LeadsList({ initialLeads }: { initialLeads: ContactSubmi
                                                         Follow-up overdue
                                                     </span>
                                                 )}
+                                                {(() => {
+                                                    const badge = scoreBadge(lead.leadScore);
+                                                    return badge ? (
+                                                        <span className={`px-2 py-0.5 rounded-full text-[10px] font-black uppercase tracking-wider border ${badge.classes}`}>
+                                                            {badge.label}
+                                                        </span>
+                                                    ) : null;
+                                                })()}
+                                                {lead.emailType === 'business' && (
+                                                    <span className="px-2 py-0.5 rounded-full text-[10px] font-black uppercase tracking-wider border bg-blue-500/10 text-blue-500 border-blue-500/30" title={lead.companyDomain}>
+                                                        Business
+                                                    </span>
+                                                )}
                                                 {lead.value !== undefined && lead.value > 0 && (
                                                     <span className="text-[11px] font-bold text-green-500">${lead.value.toLocaleString()}</span>
                                                 )}
                                                 {lead.country && (
-                                                    <span className="text-[11px] font-semibold text-foreground-muted">{countryFlag(lead.country)} {lead.country}</span>
+                                                    <span className="text-[11px] font-semibold text-foreground-muted">
+                                                        {countryFlag(lead.country)} {lead.city ? `${lead.city}, ` : ''}{lead.country}
+                                                    </span>
                                                 )}
                                                 {lead.sourcePath && (
                                                     <span className="text-[11px] font-semibold text-foreground-muted truncate">from {lead.sourcePath}</span>
@@ -551,15 +586,40 @@ export default function LeadsList({ initialLeads }: { initialLeads: ContactSubmi
                                                 <p><span className="text-foreground-muted">Submitted:</span> <span className="font-semibold text-foreground">{fullTimestamp(lead.createdAt)}</span></p>
                                                 <p><span className="text-foreground-muted">Page:</span> <span className="font-semibold text-foreground">{lead.sourcePath ?? '—'}</span></p>
                                                 <p><span className="text-foreground-muted">Landing:</span> <span className="font-semibold text-foreground">{lead.landingPage ?? '—'}</span></p>
-                                                <p><span className="text-foreground-muted">Country:</span> <span className="font-semibold text-foreground">{lead.country ? `${countryFlag(lead.country)} ${lead.country}` : '—'}</span></p>
+                                                <p>
+                                                    <span className="text-foreground-muted">Location:</span>{' '}
+                                                    <span className="font-semibold text-foreground">
+                                                        {lead.country ? `${countryFlag(lead.country)} ${[lead.city, lead.region, lead.country].filter(Boolean).join(', ')}` : '—'}
+                                                    </span>
+                                                </p>
                                                 <p className="truncate"><span className="text-foreground-muted">Referrer:</span> <span className="font-semibold text-foreground" title={lead.referrer}>{lead.referrer ?? 'Direct / none'}</span></p>
                                                 <p><span className="text-foreground-muted">UTM:</span> <span className="font-semibold text-foreground">{[lead.utmSource, lead.utmMedium, lead.utmCampaign].filter(Boolean).join(' / ') || '—'}</span></p>
                                                 <p><span className="text-foreground-muted">Device:</span> <span className="font-semibold text-foreground">{deviceFromUA(lead.userAgent)}</span></p>
+                                                <p><span className="text-foreground-muted">Language:</span> <span className="font-semibold text-foreground">{lead.language ?? '—'}</span></p>
+                                                <p>
+                                                    <span className="text-foreground-muted">Email type:</span>{' '}
+                                                    <span className="font-semibold text-foreground capitalize">
+                                                        {lead.emailType ?? '—'}{lead.companyDomain ? ` · ${lead.companyDomain}` : ''}
+                                                    </span>
+                                                </p>
+                                                <p>
+                                                    <span className="text-foreground-muted">Session:</span>{' '}
+                                                    <span className="font-semibold text-foreground">
+                                                        {lead.pageCount ? `${lead.pageCount} page${lead.pageCount === 1 ? '' : 's'} · ${formatDuration(lead.sessionSeconds)}` : '—'}
+                                                    </span>
+                                                </p>
+                                                <p><span className="text-foreground-muted">IP:</span> <span className="font-semibold text-foreground">{lead.ip ?? '—'}</span></p>
                                                 <p>
                                                     <span className="text-foreground-muted">Notification:</span>{' '}
                                                     <span className="font-semibold text-foreground capitalize">{lead.emailStatus} · {lead.emailAttempts} attempt{lead.emailAttempts === 1 ? '' : 's'}</span>
                                                 </p>
                                             </div>
+                                            {(lead.pagesVisited?.length ?? 0) > 0 && (
+                                                <p className="text-[11px] text-foreground-muted mt-1.5 break-words">
+                                                    <span className="font-bold uppercase tracking-wider">Journey:</span>{' '}
+                                                    {lead.pagesVisited!.join(' → ')}
+                                                </p>
+                                            )}
                                             {lead.lastEmailError && (
                                                 <p className="text-xs text-red-500 break-words mt-1.5">{lead.lastEmailError}</p>
                                             )}

--- a/src/lib/attribution.ts
+++ b/src/lib/attribution.ts
@@ -47,3 +47,42 @@ export function getAttribution(): Attribution {
         return {};
     }
 }
+
+const VISIT_START_KEY = 'bx-visit-start';
+const PAGES_KEY = 'bx-pages';
+
+/** Call on every route change — builds the engagement trail for lead scoring. */
+export function recordPageVisit(pathname: string): void {
+    try {
+        if (!window.sessionStorage.getItem(VISIT_START_KEY)) {
+            window.sessionStorage.setItem(VISIT_START_KEY, String(Date.now()));
+        }
+        const pages: string[] = JSON.parse(window.sessionStorage.getItem(PAGES_KEY) ?? '[]');
+        if (pages[pages.length - 1] !== pathname) {
+            pages.push(pathname);
+            window.sessionStorage.setItem(PAGES_KEY, JSON.stringify(pages.slice(-25)));
+        }
+    } catch {
+        // best-effort
+    }
+}
+
+export interface Engagement {
+    pagesVisited: string[];
+    pageCount: number;
+    sessionSeconds: number;
+}
+
+export function getEngagement(): Engagement {
+    try {
+        const pages: string[] = JSON.parse(window.sessionStorage.getItem(PAGES_KEY) ?? '[]');
+        const start = Number(window.sessionStorage.getItem(VISIT_START_KEY) ?? Date.now());
+        return {
+            pagesVisited: pages,
+            pageCount: pages.length,
+            sessionSeconds: Math.max(0, Math.round((Date.now() - start) / 1000)),
+        };
+    } catch {
+        return { pagesVisited: [], pageCount: 0, sessionSeconds: 0 };
+    }
+}

--- a/src/lib/contactStore.ts
+++ b/src/lib/contactStore.ts
@@ -35,6 +35,20 @@ export interface ContactSubmissionInput {
     referrer?: string;
     landingPage?: string;
     country?: string;
+    city?: string;
+    region?: string;
+    ip?: string;
+    /** Browser language, e.g. "en-IN". */
+    language?: string;
+    // Session engagement before submitting (client-tracked).
+    pagesVisited?: string[];
+    pageCount?: number;
+    sessionSeconds?: number;
+    // Automated enrichment.
+    emailType?: 'business' | 'personal';
+    companyDomain?: string;
+    /** 0–100 automated fit/engagement score. */
+    leadScore?: number;
 }
 
 export interface ContactSubmission extends ContactSubmissionInput {

--- a/src/lib/leadEnrichment.ts
+++ b/src/lib/leadEnrichment.ts
@@ -1,0 +1,86 @@
+import 'server-only';
+
+/**
+ * Automated lead enrichment — everything derivable from the request and the
+ * fields the visitor already filled, with zero extra questions asked.
+ */
+
+const FREE_EMAIL_DOMAINS = new Set([
+    'gmail.com', 'googlemail.com', 'yahoo.com', 'yahoo.co.in', 'yahoo.co.uk',
+    'hotmail.com', 'hotmail.co.uk', 'outlook.com', 'outlook.in', 'live.com',
+    'icloud.com', 'me.com', 'mac.com', 'aol.com', 'msn.com', 'ymail.com',
+    'protonmail.com', 'proton.me', 'pm.me', 'rediffmail.com', 'zohomail.in',
+    'mail.com', 'gmx.com', 'yandex.com',
+]);
+
+export function emailMeta(email: string): { emailType: 'business' | 'personal'; companyDomain?: string } {
+    const domain = email.split('@')[1]?.toLowerCase() ?? '';
+    if (!domain || FREE_EMAIL_DOMAINS.has(domain)) return { emailType: 'personal' };
+    return { emailType: 'business', companyDomain: domain };
+}
+
+const PHONE_COUNTRY: [string, string][] = [
+    ['+91', 'IN'], ['+1', 'US'], ['+44', 'GB'], ['+61', 'AU'], ['+971', 'AE'],
+    ['+65', 'SG'], ['+49', 'DE'], ['+33', 'FR'], ['+31', 'NL'], ['+353', 'IE'],
+    ['+64', 'NZ'], ['+81', 'JP'], ['+966', 'SA'], ['+974', 'QA'], ['+27', 'ZA'],
+];
+
+const TZ_COUNTRY: Record<string, string> = {
+    'Asia/Calcutta': 'IN', 'Asia/Kolkata': 'IN',
+    'America/New_York': 'US', 'America/Chicago': 'US', 'America/Denver': 'US',
+    'America/Los_Angeles': 'US', 'America/Phoenix': 'US',
+    'Europe/London': 'GB', 'Australia/Sydney': 'AU', 'Australia/Melbourne': 'AU',
+    'Asia/Dubai': 'AE', 'Asia/Singapore': 'SG', 'Europe/Berlin': 'DE',
+    'Europe/Paris': 'FR', 'America/Toronto': 'CA', 'America/Vancouver': 'CA',
+};
+
+/** Country with fallbacks: edge geo header → phone prefix → timezone. */
+export function deriveCountry(headerCountry: string, phone?: string, timezone?: string): string | undefined {
+    if (headerCountry) return headerCountry;
+    if (phone) {
+        // Longest prefix first so +971 wins over +9.
+        const match = PHONE_COUNTRY
+            .slice()
+            .sort((a, b) => b[0].length - a[0].length)
+            .find(([prefix]) => phone.replace(/[\s-]/g, '').startsWith(prefix));
+        if (match) return match[1];
+    }
+    if (timezone && TZ_COUNTRY[timezone]) return TZ_COUNTRY[timezone];
+    return undefined;
+}
+
+const HIGH_INTENT_PATHS = ['/services/', '/hire-ai-developers', '/ai-development-company-in-india', '/contact', '/in/services/'];
+const TARGET_MARKETS = new Set(['IN', 'US', 'GB', 'AU', 'CA', 'AE', 'SG']);
+
+export interface ScoreInput {
+    emailType: 'business' | 'personal';
+    hasPhone: boolean;
+    projectDetailsLength: number;
+    pageCount: number;
+    sessionSeconds: number;
+    sourcePath?: string;
+    landingPage?: string;
+    hasUtm: boolean;
+    country?: string;
+}
+
+/**
+ * 0–100 engagement/fit score so hot leads surface instantly.
+ * Heuristic, not ML — every rule maps to "more likely to close".
+ */
+export function computeLeadScore(input: ScoreInput): number {
+    let score = 0;
+    if (input.emailType === 'business') score += 25;
+    if (input.hasPhone) score += 15;
+    if (input.projectDetailsLength > 200) score += 15;
+    else if (input.projectDetailsLength > 50) score += 8;
+    if (input.pageCount >= 6) score += 15;
+    else if (input.pageCount >= 3) score += 10;
+    if (input.sessionSeconds >= 300) score += 15;
+    else if (input.sessionSeconds >= 120) score += 10;
+    const paths = [input.sourcePath ?? '', input.landingPage ?? ''];
+    if (paths.some((p) => HIGH_INTENT_PATHS.some((h) => p.startsWith(h) || p === h.replace(/\/$/, '')))) score += 10;
+    if (input.hasUtm) score += 5;
+    if (input.country && TARGET_MARKETS.has(input.country)) score += 5;
+    return Math.min(100, score);
+}


### PR DESCRIPTION


Every submission is now enriched fully automatically (zero extra questions for the client):

Geo & request intel:
- City + region from Vercel edge headers alongside country
- Country fallback chain: edge header -> phone prefix (+91 -> IN, etc.) -> timezone (Asia/Kolkata -> IN) — so the field populates even when the geo header is absent (local/dev or unusual routing)
- Visitor IP (first x-forwarded-for hop) and browser language

Engagement trail (client-tracked per session):
- Pages visited (ordered journey, capped at 25), page count, and time
  on site before submitting — shown as "Journey: / -> /services/... ->
  /contact" in the lead detail

Email intelligence:
- Business vs personal email detection against a free-provider list; company domain extracted for business emails ("Business" badge)

Lead scoring (0-100, heuristic):
- Business email, phone present, message depth, pages viewed, session length, high-intent source page, campaign traffic, target market
- Hot (70+) / Warm (40+) / Cold badge on every lead row, "Hottest leads" sort option, score + all new fields in the CSV export

Display: tracking panel now shows Location (city, region, country), Language, Email type, Session, IP, and the full page journey.

Note: fields populate for leads submitted after this deploys; older leads keep showing the em dash.