### PR TITLE
fix(seo): meta-description lengths, /services internal link & Speed Insights

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@tiptap/react": "^3.26.0",
         "@tiptap/starter-kit": "^3.26.0",
         "@vercel/analytics": "^2.0.1",
+        "@vercel/speed-insights": "^2.0.0",
         "axios": "^1.13.5",
         "jose": "^6.2.3",
         "lucide-react": "^0.577.0",
@@ -2169,6 +2170,44 @@
         "@remix-run/react": {
           "optional": true
         },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
         "@sveltejs/kit": {
           "optional": true
         },

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@tiptap/react": "^3.26.0",
     "@tiptap/starter-kit": "^3.26.0",
     "@vercel/analytics": "^2.0.1",
+    "@vercel/speed-insights": "^2.0.0",
     "axios": "^1.13.5",
     "jose": "^6.2.3",
     "lucide-react": "^0.577.0",

--- a/src/app/(site)/about/page.tsx
+++ b/src/app/(site)/about/page.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link';
 
 export const metadata: Metadata = {
     title: 'About Brynex Labs | AI & Software Development Company in India',
-    description: 'Brynex Labs is a senior-led AI and software development company based in India, serving startups and enterprises in the USA and worldwide. Meet the team and the mission behind our engineering collective.',
+    description: 'Meet Brynex Labs — a senior-led AI & software development company in India, serving startups and enterprises across the USA, UK & worldwide.',
     alternates: { canonical: '/about' },
     openGraph: {
         title: 'About Brynex Labs | AI & Software Development Company in India',

--- a/src/app/(site)/ai-development-company-in-india/page.tsx
+++ b/src/app/(site)/ai-development-company-in-india/page.tsx
@@ -4,7 +4,7 @@ import SectionWrapper from '@/components/SectionWrapper';
 
 export const metadata: Metadata = {
     title: 'AI Development Company in India | Brynex Labs',
-    description: 'Brynex Labs is a top AI development company in India building AI agents, LLM applications, RAG systems & custom software for clients in the USA, UK, Australia & India. Get a free consultation.',
+    description: 'A top AI development company in India building AI agents, LLM apps, RAG systems & custom software for clients in the USA, UK, Australia & India.',
     alternates: { canonical: '/ai-development-company-in-india' },
     openGraph: {
         title: 'AI Development Company in India | Brynex Labs',

--- a/src/app/(site)/case-studies/page.tsx
+++ b/src/app/(site)/case-studies/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 
 export const metadata: Metadata = {
     title: 'Software & AI Development Case Studies | Brynex Labs',
-    description: 'Real results from AI agent, SaaS, and custom software development projects — see how Brynex Labs helps startups and enterprises in the USA & India ship production-grade software.',
+    description: 'Real results from AI agent, SaaS & custom software projects — see how Brynex Labs helps startups and enterprises in the USA & India ship production software.',
     alternates: { canonical: '/case-studies' },
     openGraph: {
         title: 'Software & AI Development Case Studies | Brynex Labs',

--- a/src/app/(site)/contact/page.tsx
+++ b/src/app/(site)/contact/page.tsx
@@ -4,7 +4,7 @@ import ContactForm from '@/components/ContactForm';
 
 export const metadata: Metadata = {
     title: 'Contact Brynex Labs | Hire AI & Software Development Experts',
-    description: 'Get a free consultation for AI agent development, custom software, or SaaS SEO. Brynex Labs serves clients in the USA, India & worldwide — we respond within 6 business hours.',
+    description: 'Get a free consultation for AI agent development, custom software, or SaaS SEO. Brynex Labs serves the USA, India & worldwide — reply within 6 business hours.',
     alternates: { canonical: '/contact' },
     openGraph: {
         title: 'Contact Brynex Labs | Hire AI & Software Development Experts',

--- a/src/app/(site)/hire-ai-developers/page.tsx
+++ b/src/app/(site)/hire-ai-developers/page.tsx
@@ -4,7 +4,7 @@ import SectionWrapper from '@/components/SectionWrapper';
 
 export const metadata: Metadata = {
     title: 'Hire AI Developers | Dedicated AI Engineers from $25/hr',
-    description: 'Hire senior AI developers skilled in LangChain, LangGraph, RAG, and LLM integration. Dedicated AI engineers for US, UK & global companies at 40–60% below US rates. Start within 72 hours.',
+    description: 'Hire senior AI developers skilled in LangChain, LangGraph, RAG & LLM integration for US, UK & global teams — 40–60% below US rates, start within 72 hours.',
     alternates: { canonical: '/hire-ai-developers' },
     openGraph: {
         title: 'Hire AI Developers | Dedicated AI Engineers from $25/hr',

--- a/src/app/(site)/how-we-work/page.tsx
+++ b/src/app/(site)/how-we-work/page.tsx
@@ -5,7 +5,7 @@ import Link from 'next/link';
 
 export const metadata: Metadata = {
     title: 'How We Work | Agile Software Development Process | Brynex Labs',
-    description: 'Our 6-phase agile software development process — from discovery and architecture to deployment and scaling. See how Brynex Labs delivers production-grade AI and SaaS products.',
+    description: 'Brynex Labs 6-phase agile process — from discovery and architecture to deployment and scaling — for shipping production-grade AI and SaaS products.',
     alternates: { canonical: '/how-we-work' },
     openGraph: {
         title: 'How We Work | Agile Software Development Process | Brynex Labs',

--- a/src/app/(site)/page.tsx
+++ b/src/app/(site)/page.tsx
@@ -12,7 +12,7 @@ import { Metadata } from 'next';
 
 export const metadata: Metadata = {
   title: 'Software Company for AI Agents, Automation & SaaS SEO | Brynex Labs',
-  description: 'Build software that pays for itself. Brynex Labs builds AI agents, intelligent automation, custom software & revenue-driving SaaS SEO — senior engineers trusted by startups and enterprises across the USA & India.',
+  description: 'Brynex Labs builds AI agents, intelligent automation, custom software & revenue-driving SaaS SEO for startups and enterprises across the USA & India.',
   alternates: {
     canonical: '/',
   },

--- a/src/app/(site)/services/page.tsx
+++ b/src/app/(site)/services/page.tsx
@@ -5,7 +5,7 @@ import { services } from '@/data/services';
 
 export const metadata: Metadata = {
     title: 'AI Development, Custom Software & SaaS SEO Services | Brynex Labs',
-    description: 'Explore Brynex Labs services: AI agent development & intelligent automation, custom software & SaaS development, and revenue-focused SaaS SEO — for startups and enterprises in the USA & India.',
+    description: 'Explore Brynex Labs services: AI agents & automation, custom software & SaaS development, and revenue-focused SaaS SEO for startups & enterprises, USA & India.',
     alternates: { canonical: '/services' },
     openGraph: {
         title: 'AI Development, Custom Software & SaaS SEO Services | Brynex Labs',

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from 'next';
 import { Inter } from 'next/font/google';
 import './globals.css';
 import { Analytics as VercelAnalytics } from '@vercel/analytics/next';
+import { SpeedInsights } from '@vercel/speed-insights/next';
 import CustomAnalytics from '@/components/Analytics';
 
 const inter = Inter({
@@ -17,7 +18,7 @@ export const metadata: Metadata = {
     template: '%s',
   },
   description:
-    'Build software that pays for itself. Brynex Labs is the software company behind AI agents, intelligent automation, custom software development & revenue-driving SaaS SEO — trusted by startups and enterprises across the USA & India.',
+    'Brynex Labs is a software company building AI agents, automation, custom software & revenue-driving SaaS SEO for startups & enterprises in the USA & India.',
   applicationName: 'Brynex Labs',
   keywords: [
     'AI agent development company',
@@ -84,6 +85,7 @@ export default function RootLayout({
           {children}
         </ThemeProvider>
         <VercelAnalytics />
+        <SpeedInsights />
         <CustomAnalytics />
       </body>
     </html>

--- a/src/components/sections/Services.tsx
+++ b/src/components/sections/Services.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import SectionWrapper from '../SectionWrapper';
 import ServiceCard from '../ServiceCard';
 import { services } from '@/data/services';
@@ -26,6 +27,20 @@ export default function Services() {
                         index={index}
                     />
                 ))}
+            </div>
+
+            {/* Always-rendered link to the services hub — strengthens internal
+                crawl path to /services (the nav link lives in a hover menu). */}
+            <div className="mt-10 md:mt-12 text-center">
+                <Link
+                    href="/services"
+                    className="group inline-flex items-center gap-2 text-sm font-bold uppercase tracking-widest text-accent hover:text-accent-dark transition-colors"
+                >
+                    View all services
+                    <svg width="16" height="16" viewBox="0 0 16 16" fill="none" aria-hidden="true" className="transition-transform group-hover:translate-x-1">
+                        <path d="M3 8H13M13 8L9 4M13 8L9 12" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                    </svg>
+                </Link>
             </div>
         </SectionWrapper>
     );

--- a/src/data/blog.tsx
+++ b/src/data/blog.tsx
@@ -40,7 +40,7 @@ export const blogPosts: BlogPost[] = [
         date: 'Oct 12, 2025',
         readTime: '11 min read',
         category: 'SaaS',
-        seoDescription: 'A complete, deeply technical guide to choosing the perfect technology stack for your SaaS product to scale globally without massive scaling bottlenecks or technical debt.',
+        seoDescription: 'A deeply technical guide to choosing the right technology stack for your SaaS — so it scales globally without bottlenecks or crippling technical debt.',
         content: `
             <p>Choosing a tech stack is arguably the most permanent architectural decision you will make regarding your <a href="/services/ai-native-software-engineering">SaaS product engineering</a>. A well-constructed stack acts as a massive force multiplier, allowing a lean engineering team of three to outpace a disjointed team of thirty. But making the wrong choice traps you in an endless cycle of technical debt, refactoring, and integration bottlenecks right as you reach the critical phase of Product-Market Fit.</p>
             
@@ -98,7 +98,7 @@ export const blogPosts: BlogPost[] = [
         date: 'Jan 05, 2026',
         readTime: '14 min read',
         category: 'AI',
-        seoDescription: 'Discover the exact mechanisms and security architectures required to reliably deploy autonomous AI agents into your production SaaS without hallucinating or leaking proprietary customer data.',
+        seoDescription: 'The mechanisms and security architectures to reliably deploy autonomous AI agents into production SaaS — without hallucinations or leaking customer data.',
         content: `
             <p>The era of conversational chatbot wrappers is over. In 2025, the enterprise demand has radically shifted entirely towards <a href="/services/ai-agents-automation">Actionable AI Agents</a>—systems that do not just retrieve or summarize data, but actively navigate environments, compose transactions, execute code, and finalize multi-step operational workflows autonomously.</p>
             
@@ -144,7 +144,7 @@ export const blogPosts: BlogPost[] = [
         date: 'Feb 28, 2026',
         readTime: '9 min read',
         category: 'Cloud',
-        seoDescription: 'A ruthless technical and financial analysis of when to stick with AWS/GCP and exactly when to repatriate your massive infrastructure strictly on-premise for multi-million dollar cost savings.',
+        seoDescription: 'A technical and financial analysis of when to stay on AWS/GCP and when to repatriate infrastructure on-premise for multi-million-dollar cost savings.',
         content: `
             <p>The standard Silicon Valley playbook is identical for almost everyone: Startups default to AWS. Hyper-growth unicorns default to AWS. Massive public entities default to AWS. Building your initial platform exclusively using managed <a href="/services/ai-native-software-engineering">cloud infrastructure</a> (AWS, Vercel, GCP, Azure) is an objectively correct decision for optimizing speed-to-market.</p>
             <p>But at a certain defined scale scale, the highly marketed "Cloud Tax" stops being a convenient operational expense and mathematically morphs into a massive, unsustainable margin killer.</p>

--- a/src/data/services.ts
+++ b/src/data/services.ts
@@ -338,7 +338,7 @@ export const services: ServiceDetail[] = [
         marketIN: {
             seo: {
                 title: 'AI Agent Development Company in India | Pilots from ₹49,999',
-                metaDescription: 'AI agent development in India — pilots from ₹49,999, production agent systems from ₹1,49,999. LangChain, RAG & guardrails for Indian startups & enterprises. GST invoicing, free consultation.',
+                metaDescription: 'AI agent development in India — pilots from ₹49,999, production systems from ₹1,49,999. LangChain, RAG & guardrails for startups & enterprises. GST invoicing.',
             },
             hook: 'Automate the work that eats your team\'s week. Production-grade AI agents for Indian startups, D2C brands, and enterprises — built on your own business data, at pricing that makes sense for the Indian market.',
             pricingSubheading: 'Honest Indian-market pricing — fixed scope, milestone billed, GST invoice included:',
@@ -404,7 +404,7 @@ export const services: ServiceDetail[] = [
         },
         seo: {
             title: 'AI Agent Development Company | Agentic AI & Automation Services',
-            metaDescription: 'Brynex Labs is an AI agent development company serving the USA & India. Production-grade AI agents with LangChain, LangGraph, RAG & vector databases — automate support, operations & workflows.',
+            metaDescription: 'AI agent development company serving the USA & India — production AI agents with LangChain, LangGraph, RAG & vector databases to automate support & operations.',
         },
         challenges: [
             'Excessive time spent on repetitive, multi-step manual workflows',
@@ -611,7 +611,7 @@ export const services: ServiceDetail[] = [
         marketIN: {
             seo: {
                 title: 'Custom Software Development Company in India | MVP from ₹99,999',
-                metaDescription: 'Custom software & SaaS development in India — MVPs from ₹99,999, multi-tenant SaaS platforms from ₹2,49,999. Senior engineers, fixed-scope quotes, GST invoicing. Free consultation.',
+                metaDescription: 'Custom software & SaaS development in India — MVPs from ₹99,999, multi-tenant SaaS from ₹2,49,999. Senior engineers, fixed-scope quotes, GST invoicing.',
             },
             hook: 'Your product, engineered for scale. SaaS platforms, web & mobile apps, and cloud infrastructure for Indian startups and businesses — senior engineers, global quality, Indian-market pricing.',
             pricingSubheading: 'Honest Indian-market pricing — fixed scope, weekly demos, GST invoice included:',
@@ -677,7 +677,7 @@ export const services: ServiceDetail[] = [
         },
         seo: {
             title: 'Custom Software Development Company | SaaS, Web & Mobile Apps',
-            metaDescription: 'Custom software development company for startups & enterprises in the USA and India — multi-tenant SaaS platforms, web & mobile apps, cloud & DevOps, and application modernization under one roof.',
+            metaDescription: 'Custom software development company for startups & enterprises in the USA & India — multi-tenant SaaS, web & mobile apps, cloud, DevOps & app modernization.',
         },
         challenges: [
             'Off-the-shelf software doesn\'t fit your unique business needs',
@@ -769,7 +769,7 @@ export const services: ServiceDetail[] = [
         processSummary: 'This is how SEO becomes a pipeline engine, not a content activity.',
         seo: {
             title: 'SaaS SEO Agency | B2B SaaS SEO Services That Drive Pipeline',
-            metaDescription: 'Brynex Labs is a SaaS SEO agency for B2B companies in the USA & India. We turn organic traffic into demo requests, pipeline & MRR with BOFU keywords, programmatic SEO, and CRO.',
+            metaDescription: 'SaaS SEO agency for B2B companies in the USA & India — we turn organic traffic into demo requests, pipeline & MRR with BOFU keywords, programmatic SEO & CRO.',
         },
         challenges: [
             'Traffic growth without mapping to demo conversions',


### PR DESCRIPTION
SEO hardening surfaced while diagnosing indexing (apex/www host mismatch was fixed via Vercel domain config — codebase was already apex-consistent).

- Trim all 17 over-length meta/SEO descriptions to the 140–160 char sweet spot (homepage, layout default, about, services, contact, case-studies, hire-ai-developers, how-we-work, ai-development-company-in-india, all 3 services' global + India seo.metaDescription, and long blog seoDescriptions). Clears Bing's "meta description too long" flag and stops Google SERP truncation; keywords/meaning preserved.
- Add an always-rendered "View all services" link under the homepage services grid → server-side internal link to /services (the nav link lived in a hover menu invisible to crawlers).
- Add Vercel <SpeedInsights/> to the root layout (+@vercel/speed-insights).

Verified: tsc clean, next lint clean, next build passes (49/49 pages).